### PR TITLE
Do not force load every assemblies in the Managed folder on Mono

### DIFF
--- a/src/Reflection/ReflectionUtility.cs
+++ b/src/Reflection/ReflectionUtility.cs
@@ -74,10 +74,6 @@ public class ReflectionUtility
 
     static void SetupTypeCache()
     {
-        // For mono games, force load all 'Managed/' assemblies on startup.
-        if (Universe.Context == RuntimeContext.Mono)
-            ForceLoadManagedAssemblies();
-
         foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
             CacheTypes(asm);
 
@@ -92,24 +88,6 @@ public class ReflectionUtility
         // Universe.Log($"\t - Assembly loaded: {args.LoadedAssembly.GetName().Name}");
 
         CacheTypes(args.LoadedAssembly);
-    }
-
-    static void ForceLoadManagedAssemblies()
-    {
-        string path = Path.Combine(Application.dataPath, "Managed");
-        if (Directory.Exists(path))
-        {
-            foreach (string dllPath in Directory.GetFiles(path, "*.dll"))
-            {
-                try
-                {
-                    // load and resolve the assembly's types.
-                    Assembly asm = Assembly.LoadFrom(dllPath);
-                    asm.TryGetTypes();
-                }
-                catch { }
-            }
-        }
     }
 
     internal static void CacheTypes(Assembly asm)


### PR DESCRIPTION
I was getting a strange error for as long as I can remember when using UnityExplorer. Here it is on MelonLoader running under Wine, but I recall I could also see it on BepInEx:

![Screenshot from 2025-03-29 11-36-16](https://github.com/user-attachments/assets/75a893d7-ba8a-4eb9-99cc-56396398e16a)

With some mono env var debugging, it was found that the reason this error happens is because UniverseLib incorrectly forces to load all assemblies under the Managed folder.

This would technically be fine under normal circumstances, but this game needed to load different assemblies because Unity incorrectly stubbed SRE when building the game. It essentially means that I have to treat the corlibs the same way I would if the game dev intentionally stripped the assemblies. This is typically acomplished by prepanding a path to the mono paths which will cause that path to be checked BEFORE the Managed folder. You can check in UnityExplorer's source code for an error message relating to SRE malfunction in the C# console logic for more info: it's a very documented problem that can happen on some games.

The reason that what UniverseLib is doing is bad is because it has no way to know this: it can't know if the Managed folder contains trusted assemblies. It's possible the dev intentionally stripped them forcing the user to load unstripped versions before the Managed folder. So if UniverseLib comes and force loads them, it will break this setup because it's now possible an assembly that has yet to be resolved gets loaded from the Managed folder instead of the user specified high priority folder. 

This explains the error above: UniverseLib started to force the resolution of assemblies in the Managed folder so anytime these assemblies were needed, Mono would return the one in the Managed folder, but it should have prioritised the one in the custom user path. This caused dependency problems and it appears it affected UniverseLib because this error happens during its initialisation. It's possible however that it affects other things, even other mods in weird places because this issue isn't really deterministic and depends on the game / unstripping strategies done.

This PR removes this behavior so UniverseLib no longer force loads any assemblies in the Managed folder.