### PR TITLE
Partially fix crash with LoadFromMemory

### DIFF
--- a/src/Config/ConfigManager.cs
+++ b/src/Config/ConfigManager.cs
@@ -34,6 +34,9 @@ namespace UniverseLib.Config
 
             if (config.Disable_Setup_Force_ReLoad_ManagedAssemblies != null)
                 Disable_Setup_Force_ReLoad_ManagedAssemblies = config.Disable_Setup_Force_ReLoad_ManagedAssemblies.Value;
+
+            if (config.Disable_AssetBundles_LoadFromMemory != null)
+                Disable_AssetBundles_LoadFromMemory = config.Disable_AssetBundles_LoadFromMemory.Value;
         }
 
         /// <summary>If true, disables UniverseLib from overriding the EventSystem from the game when a UniversalUI is in use.</summary>
@@ -54,5 +57,8 @@ namespace UniverseLib.Config
 
         /// <summary>If true, Disable Force ReLoadManagedAssemblies on setup, Currently only Mono is supported</summary>
         public static bool Disable_Setup_Force_ReLoad_ManagedAssemblies { get; set; }
+
+        /// <summary>If true, disables using LoadFromMemory to load asset bundles.</summary>
+        public static bool Disable_AssetBundles_LoadFromMemory { get; set; }
     }
 }

--- a/src/Config/UniverseLibConfig.cs
+++ b/src/Config/UniverseLibConfig.cs
@@ -21,5 +21,8 @@ namespace UniverseLib.Config
 
         /// <summary>If true, Disable Force ReLoadManagedAssemblies on setup, Currently only Mono is supported</summary>
         public bool? Disable_Setup_Force_ReLoad_ManagedAssemblies;
+
+        /// <summary>If true, disables using LoadFromMemory to load asset bundles.</summary>
+        public bool? Disable_AssetBundles_LoadFromMemory;
     }
 }

--- a/src/Runtime/Il2Cpp/AssetBundle.cs
+++ b/src/Runtime/Il2Cpp/AssetBundle.cs
@@ -40,7 +40,7 @@ namespace UniverseLib
         public static AssetBundle LoadFromFile(string path)
         {
             IntPtr ptr = ICallManager.GetICallUnreliable<d_LoadFromFile>(
-                    "UnityEngine.AssetBundle::LoadFromFile_Internal", 
+                    "UnityEngine.AssetBundle::LoadFromFile_Internal",
                     "UnityEngine.AssetBundle::LoadFromFile")
                 .Invoke(IL2CPP.ManagedStringToIl2Cpp(path), 0u, 0UL);
 
@@ -58,6 +58,26 @@ namespace UniverseLib
                     "UnityEngine.AssetBundle::LoadFromMemory_Internal",
                     "UnityEngine.AssetBundle::LoadFromMemory")
                 .Invoke(((Il2CppStructArray<byte>)binary).Pointer, crc);
+
+            return ptr != IntPtr.Zero ? new AssetBundle(ptr) : null;
+        }
+
+        // AssetBundle.LoadFromStream(Stream stream)
+
+        private delegate void d_ValidateLoadFromStream(IntPtr stream);
+        private delegate IntPtr d_LoadFromStream(IntPtr stream, uint crc, uint managedReadBufferSize);
+
+        [HideFromIl2Cpp]
+        public static AssetBundle LoadFromStream(Il2CppSystem.IO.Stream stream, uint crc = 0U, uint managedReadBufferSize = 0U)
+        {
+            ICallManager.GetICallUnreliable<d_ValidateLoadFromStream>(
+                "UnityEngine.AssetBundle::ValidateLoadFromStream"
+                ).Invoke(stream.Pointer);
+
+            IntPtr ptr = ICallManager.GetICallUnreliable<d_LoadFromStream>(
+                    "UnityEngine.AssetBundle::LoadFromStreamInternal",
+                    "UnityEngine.AssetBundle::LoadFromStream")
+                .Invoke(stream.Pointer, crc, managedReadBufferSize);
 
             return ptr != IntPtr.Zero ? new AssetBundle(ptr) : null;
         }


### PR DESCRIPTION
Fixes https://github.com/yukieiji/UnityExplorer/issues/80 (kinda)

Probably the ones that it duplicates too, but I'm not sure.

This only fixes it when `ConfigManager.Disable_AssetBundles_LoadFromMemory = true` because the try/catch statement seems to ignore the IL2CPP errors (and the crash bypasses it altogether).

The issue seems to be caused by Span, and @Elmishhh found that `AssetBundle.LoadFromStream` for some reason does not use Span (yet).

I have not found a way to detect if `AssetBundle.LoadFromMemory` will error/crash beforehand, so changing the config on known games is the only way.