### PR TITLE
FixICallManagerInUnity6000

### DIFF
--- a/src/Runtime/Il2Cpp/ICallManager.cs
+++ b/src/Runtime/Il2Cpp/ICallManager.cs
@@ -35,11 +35,12 @@ namespace UniverseLib.Runtime.Il2Cpp
                 return (T)iCallCache[signature];
 
             IntPtr ptr = IL2CPP.il2cpp_resolve_icall(signature);
+            IntPtr ptr_Injected = IL2CPP.il2cpp_resolve_icall(signature + "_Injected");
 
-            if (ptr == IntPtr.Zero)
+            if (ptr == IntPtr.Zero && ptr_Injected == IntPtr.Zero)
                 throw new MissingMethodException($"Could not find any iCall with the signature '{signature}'!");
 
-            Delegate iCall = Marshal.GetDelegateForFunctionPointer(ptr, typeof(T));
+            Delegate iCall = Marshal.GetDelegateForFunctionPointer(ptr == IntPtr.Zero ? ptr_Injected : ptr, typeof(T));
             iCallCache.Add(signature, iCall);
 
             return (T)iCall;
@@ -59,7 +60,7 @@ namespace UniverseLib.Runtime.Il2Cpp
 
             T iCall;
             IntPtr ptr;
-            foreach (string sig in possibleSignatures)
+            foreach (string sig in possibleSignatures.Prepend(key + "_Injected"))
             {
                 ptr = IL2CPP.il2cpp_resolve_icall(sig);
                 if (ptr != IntPtr.Zero)

--- a/src/Runtime/Il2Cpp/ICallManager.cs
+++ b/src/Runtime/Il2Cpp/ICallManager.cs
@@ -1,4 +1,4 @@
-﻿#if CPP
+#if CPP
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -24,6 +24,7 @@ namespace UniverseLib.Runtime.Il2Cpp
 
         /// <summary>
         /// Helper to get and cache an iCall by providing the signature (eg. "UnityEngine.Resources::FindObjectsOfTypeAll").
+        /// Fixed the issue where the iCall signature parsing failed for U6000.
         /// </summary>
         /// <typeparam name="T">The Type of Delegate to provide for the iCall.</typeparam>
         /// <param name="signature">The signature of the iCall you want to get.</param>
@@ -31,16 +32,20 @@ namespace UniverseLib.Runtime.Il2Cpp
         /// <exception cref="MissingMethodException" />
         public static T GetICall<T>(string signature) where T : Delegate
         {
-            if (iCallCache.ContainsKey(signature))
-                return (T)iCallCache[signature];
-
-            IntPtr ptr = IL2CPP.il2cpp_resolve_icall(signature);
-            IntPtr ptr_Injected = IL2CPP.il2cpp_resolve_icall(signature + "_Injected");
-
-            if (ptr == IntPtr.Zero && ptr_Injected == IntPtr.Zero)
+            if (iCallCache.TryGetValue(signature, out var sig))
+            {
+                return (T)sig;
+            }
+            // In Unity 6000, most iCall signatures have been renamed from xxx to xxx_Injected.
+            if (!(
+                    TryResolveICall(signature, out var ptr) ||
+                    TryResolveICall($"{signature}_Injected", out ptr)
+                ))
+            {
                 throw new MissingMethodException($"Could not find any iCall with the signature '{signature}'!");
+            }
 
-            Delegate iCall = Marshal.GetDelegateForFunctionPointer(ptr == IntPtr.Zero ? ptr_Injected : ptr, typeof(T));
+            Delegate iCall = Marshal.GetDelegateForFunctionPointer(ptr, typeof(T));
             iCallCache.Add(signature, iCall);
 
             return (T)iCall;
@@ -49,29 +54,41 @@ namespace UniverseLib.Runtime.Il2Cpp
         /// <summary>
         /// Get an iCall which may be one of multiple different signatures (ie, the name changed in different Unity versions).
         /// Each possible signature must have the same Delegate type, it can only vary by name.
+        /// Fixed the issue where the iCall signature parsing failed for U6000.
         /// </summary>
         public static T GetICallUnreliable<T>(params string[] possibleSignatures) where T : Delegate
         {
             // use the first possible signature as the 'key'.
             string key = possibleSignatures.First();
 
-            if (unreliableCache.ContainsKey(key))
-                return (T)unreliableCache[key];
-
-            T iCall;
-            IntPtr ptr;
-            foreach (string sig in possibleSignatures.Prepend(key + "_Injected"))
+            if (unreliableCache.TryGetValue(key, out var signature))
             {
-                ptr = IL2CPP.il2cpp_resolve_icall(sig);
-                if (ptr != IntPtr.Zero)
+                return (T)signature;
+            }
+
+            var loopSig = new List<string>(possibleSignatures);
+            // In Unity 6000, most iCall signatures have been renamed from xxx to xxx_Injected.
+            loopSig.Concat(possibleSignatures.Select(s => $"{s}_Injected"));
+
+            foreach (string sig in loopSig)
+            {
+                if (TryResolveICall(sig, out var ptr))
                 {
-                    iCall = (T)Marshal.GetDelegateForFunctionPointer(ptr, typeof(T));
+                    var iCall = (T)Marshal.GetDelegateForFunctionPointer(ptr, typeof(T));
                     unreliableCache.Add(key, iCall);
                     return iCall;
                 }
             }
 
             throw new MissingMethodException($"Could not find any iCall from list of provided signatures starting with '{key}'!");
+        }
+        /// <summary>
+        /// Use out parameter modifier, redundant value retrieval can be avoided.
+        /// </summary>
+        private static bool TryResolveICall(string signature, out IntPtr ptr)
+        {
+            ptr = IL2CPP.il2cpp_resolve_icall(signature);
+            return ptr != IntPtr.Zero;
         }
     }
 }


### PR DESCRIPTION

In Unity 6000, most iCall signatures have been renamed from `xxx` to `xxx_Injected`. For example, `UnityEngine.AssetBundle::LoadFromMemory_Internal` has been changed to `UnityEngine.AssetBundle::LoadFromMemory_Internal_Injected`.

The iCall signatures used in UniverseLib do not include the `_Injected` suffix. As a result, calls to `il2cpp_resolve_icall` fail to resolve the corresponding signature and throw a `MissingMethodException`:
`Could not find any iCall from list of provided signatures starting with '{key}'!`.

This PR patches `GetICallUnreliable` and `GetICall` to support iCall signatures both with and without the `_Injected` suffix, ensuring compatibility across affected Unity versions.