### PR TITLE
fix: dropdown blocker sortingOrder too low to receive clicks

### DIFF
--- a/src/UI/UniversalUI.cs
+++ b/src/UI/UniversalUI.cs
@@ -111,6 +111,8 @@ public static class UniversalUI
         PoolHolder.transform.parent = CanvasRoot.transform;
         PoolHolder.SetActive(false);
 
+        SetupDropdownBlockerPatch();
+
         Initializing = false;
     }
 
@@ -334,5 +336,45 @@ public static class UniversalUI
         }
 
         return false;
+    }
+
+    // Dropdown blocker patch
+    //
+    // Unity's Dropdown.CreateBlocker() creates a full-screen transparent overlay to catch
+    // outside clicks. It sets the blocker's Canvas.sortingOrder to parentCanvas.sortingOrder - 1.
+    // Since UniverseLib's UIBase Canvas uses overrideSorting with a high sortingOrder (30000),
+    // the blocker ends up BELOW the panel content and never receives click events.
+    // Fix: bump the blocker's sortingOrder so it sits at the same level as the parent canvas,
+    // above panel content but below the dropdown list.
+
+    static void SetupDropdownBlockerPatch()
+    {
+        Universe.Patch(
+            typeof(Dropdown),
+            "CreateBlocker",
+            MethodType.Normal,
+            postfix: AccessTools.Method(typeof(UniversalUI), nameof(Postfix_CreateBlocker)));
+    }
+
+    static void Postfix_CreateBlocker(GameObject __result)
+    {
+        try
+        {
+            if (!__result)
+                return;
+
+            Canvas blockerCanvas = __result.GetComponent<Canvas>();
+            if (blockerCanvas != null)
+            {
+                // Undo the -1 offset applied by Unity's default CreateBlocker.
+                // This places the blocker at the same sortingOrder as the parent canvas,
+                // ensuring it renders above panel content and can receive clicks to close the dropdown.
+                blockerCanvas.sortingOrder += 1;
+            }
+        }
+        catch (Exception ex)
+        {
+            Universe.LogWarning($"Exception in Dropdown blocker patch: {ex}");
+        }
     }
 }

--- a/src/UI/UniversalUI.cs
+++ b/src/UI/UniversalUI.cs
@@ -103,6 +103,7 @@ public static class UniversalUI
     internal static void Init()
     {
         LoadBundle();
+        SetupDropdownBlockerPatch();
 
         CreateRootCanvas();
 
@@ -110,8 +111,6 @@ public static class UniversalUI
         PoolHolder = new GameObject("PoolHolder");
         PoolHolder.transform.parent = CanvasRoot.transform;
         PoolHolder.SetActive(false);
-
-        SetupDropdownBlockerPatch();
 
         Initializing = false;
     }


### PR DESCRIPTION
## Summary

Unity's `Dropdown.CreateBlocker()` creates a full-screen transparent overlay (the "blocker") to detect outside clicks and close the dropdown. It sets the blocker's `Canvas.sortingOrder` to `parentCanvas.sortingOrder - 1`.

Since UniverseLib's `UIBase` Canvas uses `overrideSorting = true` with `sortingOrder = 30000` (`TOP_SORTORDER`), the blocker ends up at sortingOrder **29999** — which is **below** the panel's own UI content. As a result, the blocker never receives click events, making it impossible to close dropdowns by clicking outside.

## Root Cause

```
Parent Canvas sortingOrder: 30000
Panel content sortingOrder: 30000 (inherits from parent)
Blocker sortingOrder:       29999 (parent - 1, set by Unity)
                            ↑ Below panel content, clicks intercepted by panel
```

## Fix

Add a Harmony Postfix on `Dropdown.CreateBlocker` that increments the blocker's `Canvas.sortingOrder` by 1 after Unity's default logic runs. This places the blocker at the **same level** as the parent canvas — above panel content but below the dropdown list — restoring the intended click-outside-to-close behavior.

## Changes

- `src/UI/UniversalUI.cs`: Added `SetupDropdownBlockerPatch()` called during `Init()`, which applies a Harmony Postfix on `Dropdown.CreateBlocker`. The postfix (`Postfix_CreateBlocker`) bumps the blocker's `Canvas.sortingOrder` by 1.

## Testing

- Verified `dotnet build` passes with 0 warnings and 0 errors
- Tested dropdown click-outside-to-close behavior works correctly after the patch