### PR TITLE
Fix: Il2Cpp "_Injected" ICall Compatibility

### DIFF
--- a/src/Reflection/Extensions.cs
+++ b/src/Reflection/Extensions.cs
@@ -88,7 +88,7 @@ public static class ReflectionExtensions
 
 #if CPP
         if (objA is Il2CppSystem.Object cppA && objB is Il2CppSystem.Object cppB
-            && Il2CppProvider.ObjectBaseToPtr(cppA) == Il2CppProvider.ObjectBaseToPtr(cppB))
+            && cppA.ToIl2CppPointer() == cppB.ToIl2CppPointer())
             return true;
 #endif
 

--- a/src/Reflection/Extensions.cs
+++ b/src/Reflection/Extensions.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using UniverseLib.Runtime.Il2Cpp;
 using UniverseLib.Utility;
+
+#if CPP
+using UniverseLib.Runtime.Il2Cpp;
+#endif
 
 namespace UniverseLib;
 

--- a/src/Reflection/Extensions.cs
+++ b/src/Reflection/Extensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using UniverseLib.Runtime.Il2Cpp;
 using UniverseLib.Utility;
 
 namespace UniverseLib;
@@ -87,7 +88,7 @@ public static class ReflectionExtensions
 
 #if CPP
         if (objA is Il2CppSystem.Object cppA && objB is Il2CppSystem.Object cppB
-            && cppA.Pointer == cppB.Pointer)
+            && Il2CppProvider.ObjectBaseToPtr(cppA) == Il2CppProvider.ObjectBaseToPtr(cppB))
             return true;
 #endif
 

--- a/src/Reflection/Il2CppReflection.cs
+++ b/src/Reflection/Il2CppReflection.cs
@@ -101,7 +101,7 @@ namespace UniverseLib
                         && type.BaseType.GetGenericTypeDefinition() == typeof(Il2CppArrayBase<>))
                         return type;
 
-                    IntPtr classPtr = IL2CPP.il2cpp_object_get_class(cppBase.Pointer);
+                    IntPtr classPtr = IL2CPP.il2cpp_object_get_class(Il2CppProvider.ObjectBaseToPtr(cppBase));
 
                     Il2CppSystem.Type cppType;
                     if (obj is Il2CppSystem.Object cppObject)
@@ -269,18 +269,19 @@ namespace UniverseLib
 
                 // Casting from il2cpp object to il2cpp object...
 
-                IntPtr castFromPtr = IL2CPP.il2cpp_object_get_class(cppObj.Pointer);
+                IntPtr objPtr = Il2CppProvider.ObjectBaseToPtr(cppObj);
+                IntPtr castFromPtr = IL2CPP.il2cpp_object_get_class(objPtr);
 
                 if (!IL2CPP.il2cpp_class_is_assignable_from(castToPtr, castFromPtr))
                     return obj;
 
                 if (RuntimeSpecificsStore.IsInjected(castToPtr)
-                    && ClassInjectorBase.GetMonoObjectFromIl2CppPointer(cppObj.Pointer) is object monoObject)
+                    && ClassInjectorBase.GetMonoObjectFromIl2CppPointer(objPtr) is object monoObject)
                     return monoObject;
 
                 try
                 {
-                    return Activator.CreateInstance(toType, cppObj.Pointer);
+                    return Activator.CreateInstance(toType, objPtr);
                 }
                 catch
                 {

--- a/src/Reflection/Il2CppReflection.cs
+++ b/src/Reflection/Il2CppReflection.cs
@@ -101,7 +101,7 @@ namespace UniverseLib
                         && type.BaseType.GetGenericTypeDefinition() == typeof(Il2CppArrayBase<>))
                         return type;
 
-                    IntPtr classPtr = IL2CPP.il2cpp_object_get_class(Il2CppProvider.ObjectBaseToPtr(cppBase));
+                    IntPtr classPtr = IL2CPP.il2cpp_object_get_class(cppBase.ToIl2CppPointer());
 
                     Il2CppSystem.Type cppType;
                     if (obj is Il2CppSystem.Object cppObject)
@@ -269,7 +269,7 @@ namespace UniverseLib
 
                 // Casting from il2cpp object to il2cpp object...
 
-                IntPtr objPtr = Il2CppProvider.ObjectBaseToPtr(cppObj);
+                IntPtr objPtr = cppObj.ToIl2CppPointer();
                 IntPtr castFromPtr = IL2CPP.il2cpp_object_get_class(objPtr);
 
                 if (!IL2CPP.il2cpp_class_is_assignable_from(castToPtr, castFromPtr))

--- a/src/Runtime/Il2Cpp/AssetBundle.cs
+++ b/src/Runtime/Il2Cpp/AssetBundle.cs
@@ -47,7 +47,7 @@ namespace UniverseLib
         {
             IntPtr ptr = IntPtr.Zero;
             d_LoadFromFile_Injected icall6 = ICallManager.GetICall<d_LoadFromFile_Injected>(
-                "UnityEngine.AssetBundle::LoadFromFile_Internal_Injected");
+                "UnityEngine.AssetBundle::LoadFromFile_Internal_Injected", false);
             if (icall6 != null)
                 unsafe
                 {
@@ -63,47 +63,19 @@ namespace UniverseLib
                     }
                 }
             else
-                ptr = ICallManager.GetICallUnreliable<d_LoadFromFile>(
+                ptr = ICallManager.GetICallUnreliable<d_LoadFromFile>(false,
                         "UnityEngine.AssetBundle::LoadFromFile_Internal", 
                         "UnityEngine.AssetBundle::LoadFromFile")
-                    .Invoke(IL2CPP.ManagedStringToIl2Cpp(path), crc, offset);
+                    ?.Invoke(IL2CPP.ManagedStringToIl2Cpp(path), crc, offset) ?? IntPtr.Zero;
 
             return ptr != IntPtr.Zero ? new AssetBundle(ptr) : null;
         }
-
-        // AssetBundle.LoadFromMemory(byte[] binary)
-
-        private delegate IntPtr d_LoadFromMemory(IntPtr binary, uint crc);
-        private delegate System.IntPtr d_LoadFromMemory_Unity6(ref ManagedSpanWrapper binary, uint crc);
 
         [HideFromIl2Cpp]
         public static AssetBundle LoadFromMemory(Il2CppStructArray<byte> binary) => LoadFromMemory(binary, 0u);
         [HideFromIl2Cpp]
         public static AssetBundle LoadFromMemory(Il2CppStructArray<byte> binary, uint crc)
         {
-            IntPtr ptr = IntPtr.Zero;
-            d_LoadFromMemory_Unity6 icall6 = ICallManager.GetICall<d_LoadFromMemory_Unity6>(
-                "UnityEngine.AssetBundle::LoadFromMemory_Internal_Injected");
-            if (icall6 != null)
-                unsafe
-                {
-                    var arrayPtr = Il2CppProvider.ObjectBaseToPtr(binary);
-                    var span = new ManagedSpanWrapper
-                    {
-                        begin = (void*)(arrayPtr + 0x20), // Skip the IL2CPP object header.
-                        length = binary.Length
-                    };
-                    var gcHandle = icall6(ref span, crc);
-                    ptr = ((gcHandle != IntPtr.Zero) ? IL2CPP.il2cpp_gchandle_get_target((uint)gcHandle) : IntPtr.Zero);
-                }
-            else
-                ptr = ICallManager.GetICallUnreliable<d_LoadFromMemory>(
-                        "UnityEngine.AssetBundle::LoadFromMemory_Internal",
-                        "UnityEngine.AssetBundle::LoadFromMemory")
-                    .Invoke(Il2CppProvider.ObjectBaseToPtr(binary), crc);
-            if (ptr != IntPtr.Zero)
-                return new AssetBundle(ptr);
-
             Il2CppSystem.IO.MemoryStream il2CppStream = new();
             il2CppStream.Write(binary, 0, binary.Length);
             il2CppStream.Flush();
@@ -120,15 +92,14 @@ namespace UniverseLib
         [HideFromIl2Cpp]
         public static AssetBundle LoadFromStream(Il2CppSystem.IO.Stream stream, uint crc, uint managedReadBufferSize)
         {
-            ICallManager.GetICallUnreliable<d_ValidateLoadFromStream>(
+            ICallManager.GetICallUnreliable<d_ValidateLoadFromStream>(false,
                 "UnityEngine.AssetBundle::ValidateLoadFromStream"
             )?.Invoke(Il2CppProvider.ObjectBaseToPtr(stream));
 
-            IntPtr ptr = ICallManager.GetICallUnreliable<d_LoadFromStream>(
-                    "UnityEngine.AssetBundle::LoadFromStreamInternal_Injected",
+            IntPtr ptr = ICallManager.GetICallUnreliable<d_LoadFromStream>(false,
                     "UnityEngine.AssetBundle::LoadFromStreamInternal",
                     "UnityEngine.AssetBundle::LoadFromStream")
-                .Invoke(Il2CppProvider.ObjectBaseToPtr(stream), crc, 0);
+                ?.Invoke(Il2CppProvider.ObjectBaseToPtr(stream), crc, 0) ?? IntPtr.Zero;
 
             return ptr != IntPtr.Zero ? new AssetBundle(ptr) : null;
         }
@@ -166,7 +137,8 @@ namespace UniverseLib
         public UnityEngine.Object[] LoadAllAssets()
         {
             IntPtr ptr = IntPtr.Zero;
-            d_LoadAssetWithSubAssets_Internal_Unity6 icall6 = ICallManager.GetICall<d_LoadAssetWithSubAssets_Internal_Unity6>("UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal_Injected");
+            d_LoadAssetWithSubAssets_Internal_Unity6 icall6 = ICallManager.GetICall<d_LoadAssetWithSubAssets_Internal_Unity6>(
+                "UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal_Injected", false);
             if (icall6 != null)
                 unsafe
                 {
@@ -183,8 +155,8 @@ namespace UniverseLib
                     }
                 }
             else
-                ptr = ICallManager.GetICall<d_LoadAssetWithSubAssets_Internal>("UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal")
-                .Invoke(m_bundlePtr, IL2CPP.ManagedStringToIl2Cpp(""), IL2CPPType.Of<UnityEngine.Object>().Pointer);
+                ptr = ICallManager.GetICall<d_LoadAssetWithSubAssets_Internal>("UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal", false)
+                    ?.Invoke(m_bundlePtr, IL2CPP.ManagedStringToIl2Cpp(""), IL2CPPType.Of<UnityEngine.Object>().Pointer) ?? IntPtr.Zero;
 
             return ptr != IntPtr.Zero ? (UnityEngine.Object[])new Il2CppReferenceArray<UnityEngine.Object>(ptr) : new UnityEngine.Object[0];
         }
@@ -198,7 +170,7 @@ namespace UniverseLib
         public T LoadAsset<T>(string name) where T : UnityEngine.Object
         {
             IntPtr ptr = IntPtr.Zero;
-            d_LoadAsset_Internal_Unity6 icall6 = ICallManager.GetICall<d_LoadAsset_Internal_Unity6>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected");
+            d_LoadAsset_Internal_Unity6 icall6 = ICallManager.GetICall<d_LoadAsset_Internal_Unity6>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected", false);
             if (icall6 != null)
                 unsafe
                 {
@@ -214,8 +186,8 @@ namespace UniverseLib
                     }
                 }
             else
-                ptr = ICallManager.GetICall<d_LoadAsset_Internal>("UnityEngine.AssetBundle::LoadAsset_Internal")
-                .Invoke(m_bundlePtr, IL2CPP.ManagedStringToIl2Cpp(name), IL2CPPType.Of<T>().Pointer);
+                ptr = ICallManager.GetICall<d_LoadAsset_Internal>("UnityEngine.AssetBundle::LoadAsset_Internal", false)
+                    ?.Invoke(m_bundlePtr, IL2CPP.ManagedStringToIl2Cpp(name), IL2CPPType.Of<T>().Pointer) ?? IntPtr.Zero;
 
             return ptr != IntPtr.Zero ? new UnityEngine.Object(ptr).TryCast<T>() : null;
         }
@@ -227,7 +199,7 @@ namespace UniverseLib
         [HideFromIl2Cpp]
         public void Unload(bool unloadAllLoadedObjects)
         {
-            d_LoadAsset_Internal_Unity6 icall6 = ICallManager.GetICall<d_LoadAsset_Internal_Unity6>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected");
+            d_LoadAsset_Internal_Unity6 icall6 = ICallManager.GetICall<d_LoadAsset_Internal_Unity6>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected", false);
             IntPtr bundlePtr = (icall6 != null) ? m_bundlePtr_Unity6 : m_bundlePtr;
             ICallManager.GetICall<d_Unload>("UnityEngine.AssetBundle::Unload")
                 .Invoke(bundlePtr, unloadAllLoadedObjects);

--- a/src/Runtime/Il2Cpp/AssetBundle.cs
+++ b/src/Runtime/Il2Cpp/AssetBundle.cs
@@ -43,27 +43,21 @@ namespace UniverseLib
         public static AssetBundle LoadFromFile(string path, uint crc, ulong offset)
         {
             IntPtr ptr = IntPtr.Zero;
-            d_LoadFromFile_Injected icall6 = ICallManager.GetICall<d_LoadFromFile_Injected>(
+            d_LoadFromFile_Injected icall_Injected = ICallManager.GetICall<d_LoadFromFile_Injected>(
                 "UnityEngine.AssetBundle::LoadFromFile_Internal_Injected", false);
-            if (icall6 != null)
-                unsafe
-                {
-                    fixed (char* charPtr = path)
-                    {
-                        var span = new ManagedSpanWrapper
-                        {
-                            begin = charPtr,
-                            length = path.Length
-                        };
-                        var gcHandle = icall6(ref span, crc, offset);
-                        ptr = ((gcHandle != IntPtr.Zero) ? IL2CPP.il2cpp_gchandle_get_target((uint)gcHandle) : IntPtr.Zero);
-                    }
-                }
+            if (icall_Injected != null)
+            {
+                IntPtr gcHandle = IntPtr.Zero;
+                ManagedSpanWrapper.Pin(path, span => gcHandle = icall_Injected(ref span, crc, offset));
+                ptr = ((gcHandle != IntPtr.Zero) ? IL2CPP.il2cpp_gchandle_get_target((uint)gcHandle) : IntPtr.Zero);
+            }
             else
+            {
                 ptr = ICallManager.GetICallUnreliable<d_LoadFromFile>(false,
-                        "UnityEngine.AssetBundle::LoadFromFile_Internal", 
+                        "UnityEngine.AssetBundle::LoadFromFile_Internal",
                         "UnityEngine.AssetBundle::LoadFromFile")
                     ?.Invoke(IL2CPP.ManagedStringToIl2Cpp(path), crc, offset) ?? IntPtr.Zero;
+            }
 
             return ptr != IntPtr.Zero ? new AssetBundle(ptr) : null;
         }
@@ -117,43 +111,39 @@ namespace UniverseLib
         // ~~~~~~~~~~~~ Instance ~~~~~~~~~~~~
 
         public readonly IntPtr m_bundlePtr = IntPtr.Zero;
-        public readonly IntPtr m_bundlePtr_Unity6 = IntPtr.Zero;
+        public readonly IntPtr m_bundlePtr_Injected = IntPtr.Zero;
 
         public AssetBundle(IntPtr ptr) : base(ptr)
         {
             m_bundlePtr = ptr;
-            m_bundlePtr_Unity6 = Marshal.ReadIntPtr(m_bundlePtr + 0x10);
+            m_bundlePtr_Injected = Marshal.ReadIntPtr(m_bundlePtr + 0x10); // Skip the Il2CppObject header + read the REAL object ptr from there.
         }
 
         // LoadAllAssets()
 
         private delegate IntPtr d_LoadAssetWithSubAssets_Internal(IntPtr _this, IntPtr name, IntPtr type);
-        private delegate IntPtr d_LoadAssetWithSubAssets_Internal_Unity6(IntPtr _this, ref ManagedSpanWrapper name, IntPtr type);
+        private delegate IntPtr d_LoadAssetWithSubAssets_Internal_Injected(IntPtr _this, ref ManagedSpanWrapper name, IntPtr type);
 
         [HideFromIl2Cpp]
         public UnityEngine.Object[] LoadAllAssets()
         {
             IntPtr ptr = IntPtr.Zero;
-            d_LoadAssetWithSubAssets_Internal_Unity6 icall6 = ICallManager.GetICall<d_LoadAssetWithSubAssets_Internal_Unity6>(
+            d_LoadAssetWithSubAssets_Internal_Injected icall_Injected = ICallManager.GetICall<d_LoadAssetWithSubAssets_Internal_Injected>(
                 "UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal_Injected", false);
-            if (icall6 != null)
-                unsafe
-                {
-                    string name = "";
-                    fixed (char* charPtr = name)
-                    {
-                        var span = new ManagedSpanWrapper
-                        {
-                            begin = charPtr,
-                            length = name.Length
-                        };
-                        var gcHandle = icall6(m_bundlePtr_Unity6, ref span, IL2CPPType.Of<UnityEngine.Object>().Pointer);
-                        ptr = ((gcHandle != IntPtr.Zero) ? Marshal.ReadIntPtr(gcHandle) : IntPtr.Zero);
-                    }
-                }
+            if (icall_Injected != null)
+            {
+                IntPtr gcHandle = IntPtr.Zero;
+                ManagedSpanWrapper.Pin("", span => gcHandle = icall_Injected(m_bundlePtr_Injected, ref span, IL2CPPType.Of<UnityEngine.Object>().Pointer));
+                ptr = ((gcHandle != IntPtr.Zero) ? Marshal.ReadIntPtr(gcHandle) : IntPtr.Zero);
+            }
             else
-                ptr = ICallManager.GetICall<d_LoadAssetWithSubAssets_Internal>("UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal", false)
-                    ?.Invoke(m_bundlePtr, IL2CPP.ManagedStringToIl2Cpp(""), IL2CPPType.Of<UnityEngine.Object>().Pointer) ?? IntPtr.Zero;
+            {
+                ptr = ICallManager
+                    .GetICall<d_LoadAssetWithSubAssets_Internal>(
+                        "UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal", false)
+                    ?.Invoke(m_bundlePtr, IL2CPP.ManagedStringToIl2Cpp(""),
+                        IL2CPPType.Of<UnityEngine.Object>().Pointer) ?? IntPtr.Zero;
+            }
 
             return ptr != IntPtr.Zero ? (UnityEngine.Object[])new Il2CppReferenceArray<UnityEngine.Object>(ptr) : new UnityEngine.Object[0];
         }
@@ -161,30 +151,25 @@ namespace UniverseLib
         // LoadAsset<T>(string name, Type type)
 
         private delegate IntPtr d_LoadAsset_Internal(IntPtr _this, IntPtr name, IntPtr type);
-        private delegate IntPtr d_LoadAsset_Internal_Unity6(IntPtr _this, ref ManagedSpanWrapper name, IntPtr type);
+        private delegate IntPtr d_LoadAsset_Internal_Injected(IntPtr _this, ref ManagedSpanWrapper name, IntPtr type);
 
         [HideFromIl2Cpp]
         public T LoadAsset<T>(string name) where T : UnityEngine.Object
         {
             IntPtr ptr = IntPtr.Zero;
-            d_LoadAsset_Internal_Unity6 icall6 = ICallManager.GetICall<d_LoadAsset_Internal_Unity6>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected", false);
-            if (icall6 != null)
-                unsafe
-                {
-                    fixed (char* charPtr = name)
-                    {
-                        var span = new ManagedSpanWrapper
-                        {
-                            begin = charPtr,
-                            length = name.Length
-                        };
-                        var gcHandle = icall6(m_bundlePtr_Unity6, ref span, IL2CPPType.Of<T>().Pointer);
-                        ptr = ((gcHandle != IntPtr.Zero) ? Marshal.ReadIntPtr(gcHandle) : IntPtr.Zero);
-                    }
-                }
+            d_LoadAsset_Internal_Injected icall_Injected = ICallManager.GetICall<d_LoadAsset_Internal_Injected>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected", false);
+            if (icall_Injected != null)
+            {
+                IntPtr gcHandle = IntPtr.Zero;
+                ManagedSpanWrapper.Pin("", span => gcHandle = icall_Injected(m_bundlePtr_Injected, ref span, IL2CPPType.Of<T>().Pointer));
+                ptr = ((gcHandle != IntPtr.Zero) ? Marshal.ReadIntPtr(gcHandle) : IntPtr.Zero);
+            }
             else
+            {
                 ptr = ICallManager.GetICall<d_LoadAsset_Internal>("UnityEngine.AssetBundle::LoadAsset_Internal", false)
-                    ?.Invoke(m_bundlePtr, IL2CPP.ManagedStringToIl2Cpp(name), IL2CPPType.Of<T>().Pointer) ?? IntPtr.Zero;
+                          ?.Invoke(m_bundlePtr, IL2CPP.ManagedStringToIl2Cpp(name), IL2CPPType.Of<T>().Pointer) ??
+                      IntPtr.Zero;
+            }
 
             return ptr != IntPtr.Zero ? new UnityEngine.Object(ptr).TryCast<T>() : null;
         }
@@ -196,8 +181,8 @@ namespace UniverseLib
         [HideFromIl2Cpp]
         public void Unload(bool unloadAllLoadedObjects)
         {
-            d_LoadAsset_Internal_Unity6 icall6 = ICallManager.GetICall<d_LoadAsset_Internal_Unity6>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected", false);
-            IntPtr bundlePtr = (icall6 != null) ? m_bundlePtr_Unity6 : m_bundlePtr;
+            d_LoadAsset_Internal_Injected icall_Injected = ICallManager.GetICall<d_LoadAsset_Internal_Injected>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected", false);
+            IntPtr bundlePtr = (icall_Injected != null) ? m_bundlePtr_Injected : m_bundlePtr;
             ICallManager.GetICall<d_Unload>("UnityEngine.AssetBundle::Unload")
                 .Invoke(bundlePtr, unloadAllLoadedObjects);
         }

--- a/src/Runtime/Il2Cpp/AssetBundle.cs
+++ b/src/Runtime/Il2Cpp/AssetBundle.cs
@@ -48,7 +48,7 @@ namespace UniverseLib
             if (icall_Injected != null)
             {
                 IntPtr gcHandle = ManagedSpanWrapper.Invoke(path, span => icall_Injected(ref span, crc, offset));
-                ptr = ((gcHandle != IntPtr.Zero) ? IL2CPP.il2cpp_gchandle_get_target((uint)gcHandle) : IntPtr.Zero);
+                ptr = ((gcHandle != IntPtr.Zero) ? Il2CppProvider.GCHandleGetTarget(gcHandle) : IntPtr.Zero);
             }
             else
             {

--- a/src/Runtime/Il2Cpp/AssetBundle.cs
+++ b/src/Runtime/Il2Cpp/AssetBundle.cs
@@ -158,7 +158,7 @@ namespace UniverseLib
             d_LoadAsset_Internal_Injected icall_Injected = ICallManager.GetICall<d_LoadAsset_Internal_Injected>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected", false);
             if (icall_Injected != null)
             {
-                IntPtr gcHandle = ManagedSpanWrapper.Invoke("", span => icall_Injected(m_bundlePtr_Injected, ref span, IL2CPPType.Of<T>().Pointer));
+                IntPtr gcHandle = ManagedSpanWrapper.Invoke(name, span => icall_Injected(m_bundlePtr_Injected, ref span, IL2CPPType.Of<T>().Pointer));
                 ptr = ((gcHandle != IntPtr.Zero) ? Marshal.ReadIntPtr(gcHandle) : IntPtr.Zero);
             }
             else

--- a/src/Runtime/Il2Cpp/AssetBundle.cs
+++ b/src/Runtime/Il2Cpp/AssetBundle.cs
@@ -82,7 +82,7 @@ namespace UniverseLib
         [HideFromIl2Cpp]
         public static AssetBundle LoadFromStream(Il2CppSystem.IO.Stream stream, uint crc, uint managedReadBufferSize)
         {
-            ICallManager.GetICallUnreliableInternal<d_ValidateLoadFromStream>(
+            ICallManager.GetICallInternal<d_ValidateLoadFromStream>(
                 "UnityEngine.AssetBundle::ValidateLoadFromStream"
             )?.Invoke(stream.ToIl2CppPointer());
 

--- a/src/Runtime/Il2Cpp/AssetBundle.cs
+++ b/src/Runtime/Il2Cpp/AssetBundle.cs
@@ -87,7 +87,7 @@ namespace UniverseLib
             if (icall6 != null)
                 unsafe
                 {
-                    var arrayPtr = IL2CPP.Il2CppObjectBaseToPtr(binary);
+                    var arrayPtr = Il2CppProvider.ObjectBaseToPtr(binary);
                     var span = new ManagedSpanWrapper
                     {
                         begin = (void*)(arrayPtr + 0x20), // Skip the IL2CPP object header.
@@ -100,7 +100,7 @@ namespace UniverseLib
                 ptr = ICallManager.GetICallUnreliable<d_LoadFromMemory>(
                         "UnityEngine.AssetBundle::LoadFromMemory_Internal",
                         "UnityEngine.AssetBundle::LoadFromMemory")
-                    .Invoke(binary.Pointer, crc);
+                    .Invoke(Il2CppProvider.ObjectBaseToPtr(binary), crc);
             if (ptr != IntPtr.Zero)
                 return new AssetBundle(ptr);
 
@@ -122,13 +122,13 @@ namespace UniverseLib
         {
             ICallManager.GetICallUnreliable<d_ValidateLoadFromStream>(
                 "UnityEngine.AssetBundle::ValidateLoadFromStream"
-            )?.Invoke(stream.Pointer);
+            )?.Invoke(Il2CppProvider.ObjectBaseToPtr(stream));
 
             IntPtr ptr = ICallManager.GetICallUnreliable<d_LoadFromStream>(
                     "UnityEngine.AssetBundle::LoadFromStreamInternal_Injected",
                     "UnityEngine.AssetBundle::LoadFromStreamInternal",
                     "UnityEngine.AssetBundle::LoadFromStream")
-                .Invoke(stream.Pointer, crc, 0);
+                .Invoke(Il2CppProvider.ObjectBaseToPtr(stream), crc, 0);
 
             return ptr != IntPtr.Zero ? new AssetBundle(ptr) : null;
         }
@@ -178,7 +178,7 @@ namespace UniverseLib
                             begin = charPtr,
                             length = name.Length
                         };
-                        var gcHandle = icall6(m_bundlePtr_Unity6, ref span, Il2CppType.Of<UnityEngine.Object>().Pointer);
+                        var gcHandle = icall6(m_bundlePtr_Unity6, ref span, IL2CPPType.Of<UnityEngine.Object>().Pointer);
                         ptr = ((gcHandle != IntPtr.Zero) ? Marshal.ReadIntPtr(gcHandle) : IntPtr.Zero);
                     }
                 }
@@ -209,7 +209,7 @@ namespace UniverseLib
                             begin = charPtr,
                             length = name.Length
                         };
-                        var gcHandle = icall6(m_bundlePtr_Unity6, ref span, Il2CppType.Of<T>().Pointer);
+                        var gcHandle = icall6(m_bundlePtr_Unity6, ref span, IL2CPPType.Of<T>().Pointer);
                         ptr = ((gcHandle != IntPtr.Zero) ? Marshal.ReadIntPtr(gcHandle) : IntPtr.Zero);
                     }
                 }

--- a/src/Runtime/Il2Cpp/AssetBundle.cs
+++ b/src/Runtime/Il2Cpp/AssetBundle.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Runtime.InteropServices;
 using UniverseLib.Runtime.Il2Cpp;
+using UniverseLib.Utility;
 #if INTEROP
 using Il2CppInterop.Runtime;
 using Il2CppInterop.Runtime.Attributes;
@@ -90,12 +91,12 @@ namespace UniverseLib
         {
             ICallManager.GetICallUnreliable<d_ValidateLoadFromStream>(false,
                 "UnityEngine.AssetBundle::ValidateLoadFromStream"
-            )?.Invoke(Il2CppProvider.ObjectBaseToPtr(stream));
+            )?.Invoke(stream.ToIl2CppPointer());
 
             IntPtr ptr = ICallManager.GetICallUnreliable<d_LoadFromStream>(false,
                     "UnityEngine.AssetBundle::LoadFromStreamInternal",
                     "UnityEngine.AssetBundle::LoadFromStream")
-                ?.Invoke(Il2CppProvider.ObjectBaseToPtr(stream), crc, 0) ?? IntPtr.Zero;
+                ?.Invoke(stream.ToIl2CppPointer(), crc, 0) ?? IntPtr.Zero;
 
             return ptr != IntPtr.Zero ? new AssetBundle(ptr) : null;
         }

--- a/src/Runtime/Il2Cpp/AssetBundle.cs
+++ b/src/Runtime/Il2Cpp/AssetBundle.cs
@@ -43,8 +43,8 @@ namespace UniverseLib
         public static AssetBundle LoadFromFile(string path, uint crc, ulong offset)
         {
             IntPtr ptr = IntPtr.Zero;
-            d_LoadFromFile_Injected icall_Injected = ICallManager.GetICall<d_LoadFromFile_Injected>(
-                "UnityEngine.AssetBundle::LoadFromFile_Internal_Injected", false);
+            d_LoadFromFile_Injected icall_Injected = ICallManager.GetICallInternal<d_LoadFromFile_Injected>(
+                "UnityEngine.AssetBundle::LoadFromFile_Internal_Injected");
             if (icall_Injected != null)
             {
                 IntPtr gcHandle = ManagedSpanWrapper.Invoke(path, span => icall_Injected(ref span, crc, offset));
@@ -52,7 +52,7 @@ namespace UniverseLib
             }
             else
             {
-                ptr = ICallManager.GetICallUnreliable<d_LoadFromFile>(false,
+                ptr = ICallManager.GetICallUnreliableInternal<d_LoadFromFile>(
                         "UnityEngine.AssetBundle::LoadFromFile_Internal",
                         "UnityEngine.AssetBundle::LoadFromFile")
                     ?.Invoke(IL2CPP.ManagedStringToIl2Cpp(path), crc, offset) ?? IntPtr.Zero;
@@ -82,11 +82,11 @@ namespace UniverseLib
         [HideFromIl2Cpp]
         public static AssetBundle LoadFromStream(Il2CppSystem.IO.Stream stream, uint crc, uint managedReadBufferSize)
         {
-            ICallManager.GetICallUnreliable<d_ValidateLoadFromStream>(false,
+            ICallManager.GetICallUnreliableInternal<d_ValidateLoadFromStream>(
                 "UnityEngine.AssetBundle::ValidateLoadFromStream"
             )?.Invoke(stream.ToIl2CppPointer());
 
-            IntPtr ptr = ICallManager.GetICallUnreliable<d_LoadFromStream>(false,
+            IntPtr ptr = ICallManager.GetICallUnreliableInternal<d_LoadFromStream>(
                     "UnityEngine.AssetBundle::LoadFromStreamInternal",
                     "UnityEngine.AssetBundle::LoadFromStream")
                 ?.Invoke(stream.ToIl2CppPointer(), crc, 0) ?? IntPtr.Zero;
@@ -127,8 +127,7 @@ namespace UniverseLib
         public UnityEngine.Object[] LoadAllAssets()
         {
             IntPtr ptr = IntPtr.Zero;
-            d_LoadAssetWithSubAssets_Internal_Injected icall_Injected = ICallManager.GetICall<d_LoadAssetWithSubAssets_Internal_Injected>(
-                "UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal_Injected", false);
+            d_LoadAssetWithSubAssets_Internal_Injected icall_Injected = ICallManager.GetICallInternal<d_LoadAssetWithSubAssets_Internal_Injected>("UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal_Injected");
             if (icall_Injected != null)
             {
                 IntPtr gcHandle = ManagedSpanWrapper.Invoke("", span => icall_Injected(m_bundlePtr_Injected, ref span, IL2CPPType.Of<UnityEngine.Object>().Pointer));
@@ -137,8 +136,7 @@ namespace UniverseLib
             else
             {
                 ptr = ICallManager
-                    .GetICall<d_LoadAssetWithSubAssets_Internal>(
-                        "UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal", false)
+                    .GetICallInternal<d_LoadAssetWithSubAssets_Internal>("UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal")
                     ?.Invoke(m_bundlePtr, IL2CPP.ManagedStringToIl2Cpp(""),
                         IL2CPPType.Of<UnityEngine.Object>().Pointer) ?? IntPtr.Zero;
             }
@@ -155,7 +153,7 @@ namespace UniverseLib
         public T LoadAsset<T>(string name) where T : UnityEngine.Object
         {
             IntPtr ptr = IntPtr.Zero;
-            d_LoadAsset_Internal_Injected icall_Injected = ICallManager.GetICall<d_LoadAsset_Internal_Injected>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected", false);
+            d_LoadAsset_Internal_Injected icall_Injected = ICallManager.GetICallInternal<d_LoadAsset_Internal_Injected>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected");
             if (icall_Injected != null)
             {
                 IntPtr gcHandle = ManagedSpanWrapper.Invoke(name, span => icall_Injected(m_bundlePtr_Injected, ref span, IL2CPPType.Of<T>().Pointer));
@@ -163,7 +161,7 @@ namespace UniverseLib
             }
             else
             {
-                ptr = ICallManager.GetICall<d_LoadAsset_Internal>("UnityEngine.AssetBundle::LoadAsset_Internal", false)
+                ptr = ICallManager.GetICallInternal<d_LoadAsset_Internal>("UnityEngine.AssetBundle::LoadAsset_Internal")
                           ?.Invoke(m_bundlePtr, IL2CPP.ManagedStringToIl2Cpp(name), IL2CPPType.Of<T>().Pointer) ??
                       IntPtr.Zero;
             }
@@ -178,7 +176,7 @@ namespace UniverseLib
         [HideFromIl2Cpp]
         public void Unload(bool unloadAllLoadedObjects)
         {
-            d_LoadAsset_Internal_Injected icall_Injected = ICallManager.GetICall<d_LoadAsset_Internal_Injected>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected", false);
+            d_LoadAsset_Internal_Injected icall_Injected = ICallManager.GetICallInternal<d_LoadAsset_Internal_Injected>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected");
             IntPtr bundlePtr = (icall_Injected != null) ? m_bundlePtr_Injected : m_bundlePtr;
             ICallManager.GetICall<d_Unload>("UnityEngine.AssetBundle::Unload")
                 .Invoke(bundlePtr, unloadAllLoadedObjects);

--- a/src/Runtime/Il2Cpp/AssetBundle.cs
+++ b/src/Runtime/Il2Cpp/AssetBundle.cs
@@ -1,10 +1,6 @@
 ﻿#if CPP
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using UnityEngine;
 using UniverseLib.Runtime.Il2Cpp;
 #if INTEROP
 using Il2CppInterop.Runtime;

--- a/src/Runtime/Il2Cpp/AssetBundle.cs
+++ b/src/Runtime/Il2Cpp/AssetBundle.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using UnityEngine;
 using UniverseLib.Runtime.Il2Cpp;
@@ -34,15 +35,38 @@ namespace UniverseLib
 
         // AssetBundle.LoadFromFile(string path)
 
-        internal delegate IntPtr d_LoadFromFile(IntPtr path, uint crc, ulong offset);
+        private delegate IntPtr d_LoadFromFile(IntPtr path, uint crc, ulong offset);
+        private delegate IntPtr d_LoadFromFile_Injected(ref ManagedSpanWrapper path, uint crc, ulong offset);
 
         [HideFromIl2Cpp]
-        public static AssetBundle LoadFromFile(string path)
+        public static AssetBundle LoadFromFile(string path) => LoadFromFile(path, 0u, 0UL);
+        [HideFromIl2Cpp]
+        public static AssetBundle LoadFromFile(string path, uint crc) => LoadFromFile(path, crc, 0UL);
+        [HideFromIl2Cpp]
+        public static AssetBundle LoadFromFile(string path, uint crc, ulong offset)
         {
-            IntPtr ptr = ICallManager.GetICallUnreliable<d_LoadFromFile>(
-                    "UnityEngine.AssetBundle::LoadFromFile_Internal", 
-                    "UnityEngine.AssetBundle::LoadFromFile")
-                .Invoke(IL2CPP.ManagedStringToIl2Cpp(path), 0u, 0UL);
+            IntPtr ptr = IntPtr.Zero;
+            d_LoadFromFile_Injected icall6 = ICallManager.GetICall<d_LoadFromFile_Injected>(
+                "UnityEngine.AssetBundle::LoadFromFile_Internal_Injected");
+            if (icall6 != null)
+                unsafe
+                {
+                    fixed (char* charPtr = path)
+                    {
+                        var span = new ManagedSpanWrapper
+                        {
+                            begin = charPtr,
+                            length = path.Length
+                        };
+                        var gcHandle = icall6(ref span, crc, offset);
+                        ptr = ((gcHandle != IntPtr.Zero) ? IL2CPP.il2cpp_gchandle_get_target((uint)gcHandle) : IntPtr.Zero);
+                    }
+                }
+            else
+                ptr = ICallManager.GetICallUnreliable<d_LoadFromFile>(
+                        "UnityEngine.AssetBundle::LoadFromFile_Internal", 
+                        "UnityEngine.AssetBundle::LoadFromFile")
+                    .Invoke(IL2CPP.ManagedStringToIl2Cpp(path), crc, offset);
 
             return ptr != IntPtr.Zero ? new AssetBundle(ptr) : null;
         }
@@ -50,36 +74,61 @@ namespace UniverseLib
         // AssetBundle.LoadFromMemory(byte[] binary)
 
         private delegate IntPtr d_LoadFromMemory(IntPtr binary, uint crc);
-
-        private delegate void d_ValidateLoadFromStream(IntPtr stream);
-        private delegate IntPtr d_LoadFromStream(IntPtr stream, uint crc, uint managedReadBufferSize);
+        private delegate System.IntPtr d_LoadFromMemory_Unity6(ref ManagedSpanWrapper binary, uint crc);
 
         [HideFromIl2Cpp]
-        public static AssetBundle LoadFromMemory(byte[] binary, uint crc = 0)
+        public static AssetBundle LoadFromMemory(Il2CppStructArray<byte> binary) => LoadFromMemory(binary, 0u);
+        [HideFromIl2Cpp]
+        public static AssetBundle LoadFromMemory(Il2CppStructArray<byte> binary, uint crc)
         {
-            var il2cppArray = new Il2CppStructArray<byte>(binary);
-            IntPtr ptr = ICallManager.GetICallUnreliable<d_LoadFromMemory>(
-                    "UnityEngine.AssetBundle::LoadFromMemory_Internal",
-                    "UnityEngine.AssetBundle::LoadFromMemory")
-                .Invoke(il2cppArray.Pointer, crc);
-
+            IntPtr ptr = IntPtr.Zero;
+            d_LoadFromMemory_Unity6 icall6 = ICallManager.GetICall<d_LoadFromMemory_Unity6>(
+                "UnityEngine.AssetBundle::LoadFromMemory_Internal_Injected");
+            if (icall6 != null)
+                unsafe
+                {
+                    var arrayPtr = IL2CPP.Il2CppObjectBaseToPtr(binary);
+                    var span = new ManagedSpanWrapper
+                    {
+                        begin = (void*)(arrayPtr + 0x20), // Skip the IL2CPP object header.
+                        length = binary.Length
+                    };
+                    var gcHandle = icall6(ref span, crc);
+                    ptr = ((gcHandle != IntPtr.Zero) ? IL2CPP.il2cpp_gchandle_get_target((uint)gcHandle) : IntPtr.Zero);
+                }
+            else
+                ptr = ICallManager.GetICallUnreliable<d_LoadFromMemory>(
+                        "UnityEngine.AssetBundle::LoadFromMemory_Internal",
+                        "UnityEngine.AssetBundle::LoadFromMemory")
+                    .Invoke(binary.Pointer, crc);
             if (ptr != IntPtr.Zero)
-            {
                 return new AssetBundle(ptr);
-            }
 
             Il2CppSystem.IO.MemoryStream il2CppStream = new();
-            il2CppStream.Write(il2cppArray, 0, il2cppArray.Length);
+            il2CppStream.Write(binary, 0, binary.Length);
             il2CppStream.Flush();
-
+            return LoadFromStream(il2CppStream);
+        }
+        
+        private delegate void d_ValidateLoadFromStream(IntPtr stream);
+        private delegate IntPtr d_LoadFromStream(IntPtr stream, uint crc, uint managedReadBufferSize);
+        
+        [HideFromIl2Cpp]
+        public static AssetBundle LoadFromStream(Il2CppSystem.IO.Stream stream) => LoadFromStream(stream, 0u, 0u);
+        [HideFromIl2Cpp]
+        public static AssetBundle LoadFromStream(Il2CppSystem.IO.Stream stream, uint crc) => LoadFromStream(stream, crc, 0u);
+        [HideFromIl2Cpp]
+        public static AssetBundle LoadFromStream(Il2CppSystem.IO.Stream stream, uint crc, uint managedReadBufferSize)
+        {
             ICallManager.GetICallUnreliable<d_ValidateLoadFromStream>(
                 "UnityEngine.AssetBundle::ValidateLoadFromStream"
-                ).Invoke(il2CppStream.Pointer);
+            )?.Invoke(stream.Pointer);
 
-            ptr = ICallManager.GetICallUnreliable<d_LoadFromStream>(
+            IntPtr ptr = ICallManager.GetICallUnreliable<d_LoadFromStream>(
+                    "UnityEngine.AssetBundle::LoadFromStreamInternal_Injected",
                     "UnityEngine.AssetBundle::LoadFromStreamInternal",
                     "UnityEngine.AssetBundle::LoadFromStream")
-                .Invoke(il2CppStream.Pointer, crc, 0);
+                .Invoke(stream.Pointer, crc, 0);
 
             return ptr != IntPtr.Zero ? new AssetBundle(ptr) : null;
         }
@@ -100,17 +149,41 @@ namespace UniverseLib
         // ~~~~~~~~~~~~ Instance ~~~~~~~~~~~~
 
         public readonly IntPtr m_bundlePtr = IntPtr.Zero;
+        public readonly IntPtr m_bundlePtr_Unity6 = IntPtr.Zero;
 
-        public AssetBundle(IntPtr ptr) : base(ptr) { m_bundlePtr = ptr; }
+        public AssetBundle(IntPtr ptr) : base(ptr)
+        {
+            m_bundlePtr = ptr;
+            m_bundlePtr_Unity6 = Marshal.ReadIntPtr(m_bundlePtr + 0x10);
+        }
 
         // LoadAllAssets()
 
-        internal delegate IntPtr d_LoadAssetWithSubAssets_Internal(IntPtr _this, IntPtr name, IntPtr type);
+        private delegate IntPtr d_LoadAssetWithSubAssets_Internal(IntPtr _this, IntPtr name, IntPtr type);
+        private delegate IntPtr d_LoadAssetWithSubAssets_Internal_Unity6(IntPtr _this, ref ManagedSpanWrapper name, IntPtr type);
 
         [HideFromIl2Cpp]
         public UnityEngine.Object[] LoadAllAssets()
         {
-            IntPtr ptr = ICallManager.GetICall<d_LoadAssetWithSubAssets_Internal>("UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal")
+            IntPtr ptr = IntPtr.Zero;
+            d_LoadAssetWithSubAssets_Internal_Unity6 icall6 = ICallManager.GetICall<d_LoadAssetWithSubAssets_Internal_Unity6>("UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal_Injected");
+            if (icall6 != null)
+                unsafe
+                {
+                    string name = "";
+                    fixed (char* charPtr = name)
+                    {
+                        var span = new ManagedSpanWrapper
+                        {
+                            begin = charPtr,
+                            length = name.Length
+                        };
+                        var gcHandle = icall6(m_bundlePtr_Unity6, ref span, Il2CppType.Of<UnityEngine.Object>().Pointer);
+                        ptr = ((gcHandle != IntPtr.Zero) ? Marshal.ReadIntPtr(gcHandle) : IntPtr.Zero);
+                    }
+                }
+            else
+                ptr = ICallManager.GetICall<d_LoadAssetWithSubAssets_Internal>("UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal")
                 .Invoke(m_bundlePtr, IL2CPP.ManagedStringToIl2Cpp(""), IL2CPPType.Of<UnityEngine.Object>().Pointer);
 
             return ptr != IntPtr.Zero ? (UnityEngine.Object[])new Il2CppReferenceArray<UnityEngine.Object>(ptr) : new UnityEngine.Object[0];
@@ -118,12 +191,30 @@ namespace UniverseLib
 
         // LoadAsset<T>(string name, Type type)
 
-        internal delegate IntPtr d_LoadAsset_Internal(IntPtr _this, IntPtr name, IntPtr type);
+        private delegate IntPtr d_LoadAsset_Internal(IntPtr _this, IntPtr name, IntPtr type);
+        private delegate IntPtr d_LoadAsset_Internal_Unity6(IntPtr _this, ref ManagedSpanWrapper name, IntPtr type);
 
         [HideFromIl2Cpp]
         public T LoadAsset<T>(string name) where T : UnityEngine.Object
         {
-            IntPtr ptr = ICallManager.GetICall<d_LoadAsset_Internal>("UnityEngine.AssetBundle::LoadAsset_Internal")
+            IntPtr ptr = IntPtr.Zero;
+            d_LoadAsset_Internal_Unity6 icall6 = ICallManager.GetICall<d_LoadAsset_Internal_Unity6>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected");
+            if (icall6 != null)
+                unsafe
+                {
+                    fixed (char* charPtr = name)
+                    {
+                        var span = new ManagedSpanWrapper
+                        {
+                            begin = charPtr,
+                            length = name.Length
+                        };
+                        var gcHandle = icall6(m_bundlePtr_Unity6, ref span, Il2CppType.Of<T>().Pointer);
+                        ptr = ((gcHandle != IntPtr.Zero) ? Marshal.ReadIntPtr(gcHandle) : IntPtr.Zero);
+                    }
+                }
+            else
+                ptr = ICallManager.GetICall<d_LoadAsset_Internal>("UnityEngine.AssetBundle::LoadAsset_Internal")
                 .Invoke(m_bundlePtr, IL2CPP.ManagedStringToIl2Cpp(name), IL2CPPType.Of<T>().Pointer);
 
             return ptr != IntPtr.Zero ? new UnityEngine.Object(ptr).TryCast<T>() : null;
@@ -131,13 +222,15 @@ namespace UniverseLib
 
         // Unload(bool unloadAllLoadedObjects);
 
-        internal delegate void d_Unload(IntPtr _this, bool unloadAllLoadedObjects);
+        private delegate void d_Unload(IntPtr _this, bool unloadAllLoadedObjects);
 
         [HideFromIl2Cpp]
         public void Unload(bool unloadAllLoadedObjects)
         {
+            d_LoadAsset_Internal_Unity6 icall6 = ICallManager.GetICall<d_LoadAsset_Internal_Unity6>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected");
+            IntPtr bundlePtr = (icall6 != null) ? m_bundlePtr_Unity6 : m_bundlePtr;
             ICallManager.GetICall<d_Unload>("UnityEngine.AssetBundle::Unload")
-                .Invoke(this.m_bundlePtr, unloadAllLoadedObjects);
+                .Invoke(bundlePtr, unloadAllLoadedObjects);
         }
     }
 }

--- a/src/Runtime/Il2Cpp/AssetBundle.cs
+++ b/src/Runtime/Il2Cpp/AssetBundle.cs
@@ -47,8 +47,7 @@ namespace UniverseLib
                 "UnityEngine.AssetBundle::LoadFromFile_Internal_Injected", false);
             if (icall_Injected != null)
             {
-                IntPtr gcHandle = IntPtr.Zero;
-                ManagedSpanWrapper.Pin(path, span => gcHandle = icall_Injected(ref span, crc, offset));
+                IntPtr gcHandle = ManagedSpanWrapper.Invoke(path, span => icall_Injected(ref span, crc, offset));
                 ptr = ((gcHandle != IntPtr.Zero) ? IL2CPP.il2cpp_gchandle_get_target((uint)gcHandle) : IntPtr.Zero);
             }
             else
@@ -132,8 +131,7 @@ namespace UniverseLib
                 "UnityEngine.AssetBundle::LoadAssetWithSubAssets_Internal_Injected", false);
             if (icall_Injected != null)
             {
-                IntPtr gcHandle = IntPtr.Zero;
-                ManagedSpanWrapper.Pin("", span => gcHandle = icall_Injected(m_bundlePtr_Injected, ref span, IL2CPPType.Of<UnityEngine.Object>().Pointer));
+                IntPtr gcHandle = ManagedSpanWrapper.Invoke("", span => icall_Injected(m_bundlePtr_Injected, ref span, IL2CPPType.Of<UnityEngine.Object>().Pointer));
                 ptr = ((gcHandle != IntPtr.Zero) ? Marshal.ReadIntPtr(gcHandle) : IntPtr.Zero);
             }
             else
@@ -160,8 +158,7 @@ namespace UniverseLib
             d_LoadAsset_Internal_Injected icall_Injected = ICallManager.GetICall<d_LoadAsset_Internal_Injected>("UnityEngine.AssetBundle::LoadAsset_Internal_Injected", false);
             if (icall_Injected != null)
             {
-                IntPtr gcHandle = IntPtr.Zero;
-                ManagedSpanWrapper.Pin("", span => gcHandle = icall_Injected(m_bundlePtr_Injected, ref span, IL2CPPType.Of<T>().Pointer));
+                IntPtr gcHandle = ManagedSpanWrapper.Invoke("", span => icall_Injected(m_bundlePtr_Injected, ref span, IL2CPPType.Of<T>().Pointer));
                 ptr = ((gcHandle != IntPtr.Zero) ? Marshal.ReadIntPtr(gcHandle) : IntPtr.Zero);
             }
             else

--- a/src/Runtime/Il2Cpp/ICallManager.cs
+++ b/src/Runtime/Il2Cpp/ICallManager.cs
@@ -30,7 +30,7 @@ namespace UniverseLib.Runtime.Il2Cpp
         /// <param name="signature">The signature of the iCall you want to get.</param>
         /// <returns>The <typeparamref name="T"/> delegate if successful.</returns>
         /// <exception cref="MissingMethodException" />
-        public static T GetICall<T>(string signature) where T : Delegate
+        public static T GetICall<T>(string signature, bool throwException = true) where T : Delegate
         {
             if (iCallCache.TryGetValue(signature, out var sig))
             {
@@ -42,7 +42,10 @@ namespace UniverseLib.Runtime.Il2Cpp
                     TryResolveICall($"{signature}_Injected", out ptr)
                 ))
             {
-                throw new MissingMethodException($"Could not find any iCall with the signature '{signature}'!");
+                if (throwException)
+                    throw new MissingMethodException($"Could not find any iCall with the signature '{signature}'!");
+                else
+                    return null;
             }
 
             Delegate iCall = Marshal.GetDelegateForFunctionPointer(ptr, typeof(T));
@@ -57,6 +60,9 @@ namespace UniverseLib.Runtime.Il2Cpp
         /// Fixed the issue where the iCall signature parsing failed for U6000.
         /// </summary>
         public static T GetICallUnreliable<T>(params string[] possibleSignatures) where T : Delegate
+            => GetICallUnreliable<T>(true, possibleSignatures);
+        public static T GetICallUnreliable<T>(bool throwException, params string[] possibleSignatures) 
+            where T : Delegate
         {
             // use the first possible signature as the 'key'.
             string key = possibleSignatures.First();
@@ -80,8 +86,11 @@ namespace UniverseLib.Runtime.Il2Cpp
                 }
             }
 
-            throw new MissingMethodException($"Could not find any iCall from list of provided signatures starting with '{key}'!");
+            if (throwException)
+                throw new MissingMethodException($"Could not find any iCall from list of provided signatures starting with '{key}'!");
+            return null;
         }
+        
         /// <summary>
         /// Use out parameter modifier, redundant value retrieval can be avoided.
         /// </summary>

--- a/src/Runtime/Il2Cpp/ICallManager.cs
+++ b/src/Runtime/Il2Cpp/ICallManager.cs
@@ -30,7 +30,22 @@ namespace UniverseLib.Runtime.Il2Cpp
         /// <param name="signature">The signature of the iCall you want to get.</param>
         /// <returns>The <typeparamref name="T"/> delegate if successful.</returns>
         /// <exception cref="MissingMethodException" />
-        public static T GetICall<T>(string signature, bool throwException = true) where T : Delegate
+        public static T GetICall<T>(string signature) where T : Delegate
+        {
+            T icall = GetICallInternal<T>(signature);
+            if (icall == null)
+                throw new MissingMethodException($"Could not find any iCall with the signature '{signature}'!");
+            return icall;
+        }
+        
+        /// <summary>
+        /// Helper to get and cache an iCall by providing the signature (eg. "UnityEngine.Resources::FindObjectsOfTypeAll").
+        /// Fixed the issue where the iCall signature parsing failed for U6000.
+        /// </summary>
+        /// <typeparam name="T">The Type of Delegate to provide for the iCall.</typeparam>
+        /// <param name="signature">The signature of the iCall you want to get.</param>
+        /// <returns>The <typeparamref name="T"/> delegate if successful.</returns>
+        public static T GetICallInternal<T>(string signature) where T : Delegate
         {
             if (iCallCache.TryGetValue(signature, out var sig))
             {
@@ -41,11 +56,8 @@ namespace UniverseLib.Runtime.Il2Cpp
                     TryResolveICall(signature, out var ptr) ||
                     TryResolveICall($"{signature}_Injected", out ptr)
                 ))
-            {
-                if (throwException)
-                    throw new MissingMethodException($"Could not find any iCall with the signature '{signature}'!");
-                else
-                    return null;
+            { 
+                return null;
             }
 
             Delegate iCall = Marshal.GetDelegateForFunctionPointer(ptr, typeof(T));
@@ -60,9 +72,19 @@ namespace UniverseLib.Runtime.Il2Cpp
         /// Fixed the issue where the iCall signature parsing failed for U6000.
         /// </summary>
         public static T GetICallUnreliable<T>(params string[] possibleSignatures) where T : Delegate
-            => GetICallUnreliable<T>(true, possibleSignatures);
-        public static T GetICallUnreliable<T>(bool throwException, params string[] possibleSignatures) 
-            where T : Delegate
+        {
+            T icall = GetICallUnreliableInternal<T>(possibleSignatures);
+            if (icall == null)
+                throw new MissingMethodException($"Could not find any iCall from list of provided signatures starting with '{possibleSignatures.First()}'!");
+            return icall;
+        }
+
+        /// <summary>
+        /// Get an iCall which may be one of multiple different signatures (ie, the name changed in different Unity versions).
+        /// Each possible signature must have the same Delegate type, it can only vary by name.
+        /// Fixed the issue where the iCall signature parsing failed for U6000.
+        /// </summary>
+        public static T GetICallUnreliableInternal<T>(params string[] possibleSignatures) where T : Delegate
         {
             // use the first possible signature as the 'key'.
             string key = possibleSignatures.First();
@@ -86,8 +108,6 @@ namespace UniverseLib.Runtime.Il2Cpp
                 }
             }
 
-            if (throwException)
-                throw new MissingMethodException($"Could not find any iCall from list of provided signatures starting with '{key}'!");
             return null;
         }
         

--- a/src/Runtime/Il2Cpp/Il2CppManagedEnumerator.cs
+++ b/src/Runtime/Il2Cpp/Il2CppManagedEnumerator.cs
@@ -25,7 +25,7 @@ namespace UniverseLib.Runtime.Il2Cpp
     public static class CollectionExtensions
     {
         public static Il2CppIEnumerator WrapToIl2Cpp(this IEnumerator self)
-            => new(new Il2CppManagedEnumerator(self).Pointer);
+            => new(Il2CppProvider.ObjectBaseToPtr(new Il2CppManagedEnumerator(self)));
     }
 
     public class Il2CppManagedEnumerator : Object

--- a/src/Runtime/Il2Cpp/Il2CppManagedEnumerator.cs
+++ b/src/Runtime/Il2Cpp/Il2CppManagedEnumerator.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Reflection.Emit;
 using HarmonyLib;
 using Il2CppSystem;
+using UniverseLib.Utility;
 using IntPtr = System.IntPtr;
 using Type = System.Type;
 using ArgumentNullException = System.ArgumentNullException;
@@ -25,7 +26,7 @@ namespace UniverseLib.Runtime.Il2Cpp
     public static class CollectionExtensions
     {
         public static Il2CppIEnumerator WrapToIl2Cpp(this IEnumerator self)
-            => new(Il2CppProvider.ObjectBaseToPtr(new Il2CppManagedEnumerator(self)));
+            => new(new Il2CppManagedEnumerator(self).ToIl2CppPointer());
     }
 
     public class Il2CppManagedEnumerator : Object

--- a/src/Runtime/Il2Cpp/Il2CppProvider.cs
+++ b/src/Runtime/Il2Cpp/Il2CppProvider.cs
@@ -44,12 +44,6 @@ namespace UniverseLib.Runtime.Il2Cpp
         {
             new Il2CppTextureHelper();
         }
-        
-        internal static IntPtr ObjectBaseToPtr<T>(T obj) 
-            where T : Il2CppObjectBase
-        {
-            return IL2CPP.Il2CppObjectBaseToPtr(obj);
-        }
 
         /// <inheritdoc/>
         protected internal override Coroutine Internal_StartCoroutine(IEnumerator routine)
@@ -117,7 +111,7 @@ namespace UniverseLib.Runtime.Il2Cpp
 
             Il2CppSystem.Collections.Generic.List<GameObject> list = new(count);
             ICallManager.GetICall<d_GetRootGameObjects>("UnityEngine.SceneManagement.Scene::GetRootGameObjectsInternal")
-                .Invoke(scene.handle, ObjectBaseToPtr(list));
+                .Invoke(scene.handle, list.ToIl2CppPointer());
             return list.ToArray();
         }
 

--- a/src/Runtime/Il2Cpp/Il2CppProvider.cs
+++ b/src/Runtime/Il2Cpp/Il2CppProvider.cs
@@ -166,6 +166,12 @@ namespace UniverseLib.Runtime.Il2Cpp
 
             SetColorBlock(selectable, (ColorBlock)boxedColors);
         }
+        
+        // Il2CppInterop changed parameters from uint to nint
+        // We call IL2CPP.il2cpp_gchandle_get_target using Reflection to automatically handle value conversion
+        private static MethodInfo _gcHandleGetTarget = typeof(IL2CPP).GetMethod("il2cpp_gchandle_get_target", BindingFlags.Public | BindingFlags.Static);
+        protected internal static IntPtr GCHandleGetTarget(IntPtr gcHandle)
+            => (IntPtr)_gcHandleGetTarget.Invoke(null, [gcHandle]);
     }
 }
 

--- a/src/Runtime/Il2Cpp/Il2CppProvider.cs
+++ b/src/Runtime/Il2Cpp/Il2CppProvider.cs
@@ -14,7 +14,10 @@ using HarmonyLib;
 using UniverseLib.Utility;
 #if INTEROP
 using Il2CppInterop.Runtime;
+using Il2CppInterop.Runtime.InteropTypes;
 using Il2CppInterop.Runtime.InteropTypes.Arrays;
+using Il2CppInterop.Runtime.Runtime;
+
 #else
 using UnhollowerRuntimeLib;
 using UnhollowerBaseLib;
@@ -40,6 +43,12 @@ namespace UniverseLib.Runtime.Il2Cpp
         protected internal override void OnInitialize()
         {
             new Il2CppTextureHelper();
+        }
+        
+        internal static IntPtr ObjectBaseToPtr<T>(T obj) 
+            where T : Il2CppObjectBase
+        {
+            return IL2CPP.Il2CppObjectBaseToPtr(obj);
         }
 
         /// <inheritdoc/>
@@ -108,7 +117,7 @@ namespace UniverseLib.Runtime.Il2Cpp
 
             Il2CppSystem.Collections.Generic.List<GameObject> list = new(count);
             ICallManager.GetICall<d_GetRootGameObjects>("UnityEngine.SceneManagement.Scene::GetRootGameObjectsInternal")
-                .Invoke(scene.handle, list.Pointer);
+                .Invoke(scene.handle, ObjectBaseToPtr(list));
             return list.ToArray();
         }
 

--- a/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
+++ b/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
@@ -8,6 +8,8 @@ using UnityEngine;
 using UniverseLib.Config;
 #if INTEROP
 using Il2CppInterop.Runtime.InteropTypes.Arrays;
+using UnityEngine.Experimental.Rendering;
+
 #else
 using UnhollowerBaseLib;
 #endif
@@ -25,7 +27,7 @@ namespace UniverseLib.Runtime.Il2Cpp
 
         internal delegate void d_CopyTexture_Region(IntPtr src, int srcElement, int srcMip, int srcX, int srcY,
             int srcWidth, int srcHeight, IntPtr dst, int dstElement, int dstMip, int dstX, int dstY);
-
+        
         protected internal override Texture2D Internal_NewTexture2D(int width, int height)
         {
             return new(width, height, TextureFormat.RGBA32, 1, false, IntPtr.Zero);
@@ -45,14 +47,14 @@ namespace UniverseLib.Runtime.Il2Cpp
             else
             {
                 ICallManager.GetICall<d_Blit2>("UnityEngine.Graphics::Blit2")
-                    .Invoke(tex.Pointer, rt.Pointer);
+                    .Invoke(Il2CppProvider.ObjectBaseToPtr(tex), Il2CppProvider.ObjectBaseToPtr(rt));
             }
         }
 
         protected internal override byte[] Internal_EncodeToPNG(Texture2D tex)
         {
             IntPtr arrayPtr = ICallManager.GetICall<d_EncodeToPNG>("UnityEngine.ImageConversion::EncodeToPNG")
-                .Invoke(tex.Pointer);
+                .Invoke(Il2CppProvider.ObjectBaseToPtr(tex));
 
             return arrayPtr == IntPtr.Zero ? null : new Il2CppStructArray<byte>(arrayPtr);
         }
@@ -60,25 +62,42 @@ namespace UniverseLib.Runtime.Il2Cpp
         protected internal override Sprite Internal_CreateSprite(Texture2D texture)
         {
             var rect = new Rect(0, 0, texture.width, texture.height);
-            return
-                ConfigManager.Bypass_UniverseLib_ICall ?
-                Sprite.Create(texture, rect, Vector2.zero, 100f, 0u, SpriteMeshType.Tight, Vector4.zero) :
-                CreateSpriteImpl(texture, rect, Vector2.zero, 100f, 0u, Vector4.zero);
+            return CreateSpriteImpl(texture, rect, Vector2.zero, 100f, 0u, SpriteMeshType.Tight, Vector4.zero, false);
         }
 
         protected internal override Sprite Internal_CreateSprite(Texture2D texture, Rect rect, Vector2 pivot, float pixelsPerUnit, uint extrude, Vector4 border)
         {
-            return
-                ConfigManager.Bypass_UniverseLib_ICall ?
-                Sprite.Create(texture, rect, pivot, pixelsPerUnit, extrude, SpriteMeshType.Tight, border) :
-                CreateSpriteImpl(texture, rect, pivot, pixelsPerUnit, extrude, border);
+            return CreateSpriteImpl(texture, rect, pivot, pixelsPerUnit, extrude, SpriteMeshType.Tight, border, false);
         }
 
-        internal static Sprite CreateSpriteImpl(Texture texture, Rect rect, Vector2 pivot, float pixelsPerUnit, uint extrude, Vector4 border)
+        internal static Sprite CreateSpriteImpl(Texture2D texture, 
+            Rect rect, 
+            Vector2 pivot, 
+            float pixelsPerUnit,
+            uint extrude, 
+            SpriteMeshType meshtype,
+            Vector4 border,
+            bool generateFallbackPhysicsShape)
         {
-            IntPtr spritePtr = ICallManager.GetICall<d_CreateSprite>("UnityEngine.Sprite::CreateSprite_Injected")
-                .Invoke(texture.Pointer, ref rect, ref pivot, pixelsPerUnit, extrude, 1, ref border, false);
-
+            try
+            {
+                Sprite sprite = Sprite.CreateSprite(texture, rect, pivot, pixelsPerUnit, extrude,
+                    meshtype, border, generateFallbackPhysicsShape);
+                if (sprite != null)
+                    return sprite;
+            }
+            catch { }
+            
+            if (ConfigManager.Bypass_UniverseLib_ICall)
+                return null;
+            
+            d_CreateSprite icall = ICallManager.GetICall<d_CreateSprite>("UnityEngine.Sprite::CreateSprite");
+            if (icall == null)
+                icall = ICallManager.GetICall<d_CreateSprite>("UnityEngine.Sprite::CreateSprite_Injected");
+            if (icall == null)
+                return null;
+            
+            IntPtr spritePtr = icall.Invoke(Il2CppProvider.ObjectBaseToPtr(texture), ref rect, ref pivot, pixelsPerUnit, extrude, 1, ref border, false);
             return spritePtr == IntPtr.Zero ? null : new Sprite(spritePtr);
         }
 
@@ -97,7 +116,7 @@ namespace UniverseLib.Runtime.Il2Cpp
             else
             {
                 ICallManager.GetICall<d_CopyTexture_Region>("UnityEngine.Graphics::CopyTexture_Region")
-                    .Invoke(src.Pointer, srcElement, srcMip, srcX, srcY, srcWidth, srcHeight, dst.Pointer, dstElement, dstMip, dstX, dstY);
+                    .Invoke(Il2CppProvider.ObjectBaseToPtr(src), srcElement, srcMip, srcX, srcY, srcWidth, srcHeight, Il2CppProvider.ObjectBaseToPtr(dst), dstElement, dstMip, dstX, dstY);
             }
             return dst;
         }

--- a/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
+++ b/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
 using UniverseLib.Config;
+using UniverseLib.Utility;
 #if INTEROP
 using Il2CppInterop.Runtime.InteropTypes.Arrays;
 using UnityEngine.Experimental.Rendering;
@@ -48,14 +49,14 @@ namespace UniverseLib.Runtime.Il2Cpp
             else
             {
                 ICallManager.GetICall<d_Blit2>("UnityEngine.Graphics::Blit2")
-                    .Invoke(Il2CppProvider.ObjectBaseToPtr(tex), Il2CppProvider.ObjectBaseToPtr(rt));
+                    .Invoke(tex.ToIl2CppPointer(), rt.ToIl2CppPointer());
             }
         }
 
         protected internal override byte[] Internal_EncodeToPNG(Texture2D tex)
         {
             IntPtr arrayPtr = ICallManager.GetICall<d_EncodeToPNG>("UnityEngine.ImageConversion::EncodeToPNG")
-                .Invoke(Il2CppProvider.ObjectBaseToPtr(tex));
+                .Invoke(tex.ToIl2CppPointer());
 
             return arrayPtr == IntPtr.Zero ? null : new Il2CppStructArray<byte>(arrayPtr);
         }
@@ -97,7 +98,7 @@ namespace UniverseLib.Runtime.Il2Cpp
             if (icall == null)
                 return null;
             
-            IntPtr spritePtr = icall.Invoke(Il2CppProvider.ObjectBaseToPtr(texture), ref rect, ref pivot, pixelsPerUnit, extrude, 1, ref border, false);
+            IntPtr spritePtr = icall.Invoke(texture.ToIl2CppPointer(), ref rect, ref pivot, pixelsPerUnit, extrude, 1, ref border, false);
             return spritePtr == IntPtr.Zero ? null : new Sprite(spritePtr);
         }
 
@@ -116,7 +117,7 @@ namespace UniverseLib.Runtime.Il2Cpp
             else
             {
                 ICallManager.GetICall<d_CopyTexture_Region>("UnityEngine.Graphics::CopyTexture_Region")
-                    .Invoke(Il2CppProvider.ObjectBaseToPtr(src), srcElement, srcMip, srcX, srcY, srcWidth, srcHeight, Il2CppProvider.ObjectBaseToPtr(dst), dstElement, dstMip, dstX, dstY);
+                    .Invoke(src.ToIl2CppPointer(), srcElement, srcMip, srcX, srcY, srcWidth, srcHeight, dst.ToIl2CppPointer(), dstElement, dstMip, dstX, dstY);
             }
             return dst;
         }

--- a/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
+++ b/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
@@ -71,9 +71,6 @@ namespace UniverseLib.Runtime.Il2Cpp
             return CreateSpriteImpl(texture, rect, pivot, pixelsPerUnit, extrude, SpriteMeshType.Tight, border, false);
         }
 
-        private static MethodInfo _spriteCreateSpriteMethod = typeof(Sprite)
-            .GetMethods(BindingFlags.Public | BindingFlags.Static)
-            .LastOrDefault(x => x.Name == "CreateSprite");
         internal static Sprite CreateSpriteImpl(Texture2D texture, 
             Rect rect, 
             Vector2 pivot, 

--- a/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
+++ b/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
@@ -24,6 +24,11 @@ namespace UniverseLib.Runtime.Il2Cpp
 
         internal delegate void d_Blit2(IntPtr source, IntPtr dest);
 
+        internal delegate IntPtr d_CreateSprite(IntPtr texture, ref Rect rect, ref Vector2 pivot, float pixelsPerUnit,
+            uint extrude, int meshType, ref Vector4 border, bool generateFallbackPhysicsShape);
+        internal delegate IntPtr d_CreateSprite_Secondary(IntPtr texture, ref Rect rect, ref Vector2 pivot, float pixelsPerUnit,
+            uint extrude, int meshType, ref Vector4 border, bool generateFallbackPhysicsShape, object[] secondaryTexture);
+        
         internal delegate void d_CopyTexture_Region(IntPtr src, int srcElement, int srcMip, int srcX, int srcY,
             int srcWidth, int srcHeight, IntPtr dst, int dstElement, int dstMip, int dstX, int dstY);
         
@@ -90,26 +95,56 @@ namespace UniverseLib.Runtime.Il2Cpp
             Vector4 border,
             bool generateFallbackPhysicsShape)
         {
-            try
+            if (ConfigManager.Bypass_UniverseLib_ICall)
             {
-                return (Sprite)_spriteCreate.Invoke(null, [
-                    texture, rect, pivot, pixelsPerUnit, extrude,
-                    meshtype, border, generateFallbackPhysicsShape]);
+                try
+                {
+                    return (Sprite)_spriteCreate.Invoke(null, [
+                        texture, rect, pivot, pixelsPerUnit, extrude,
+                        meshtype, border, generateFallbackPhysicsShape
+                    ]);
+                }
+                catch (Exception ex)
+                {
+                    Universe.LogWarning(ex);
+                }
+
+                try
+                {
+                    return (Sprite)_spriteCreateSprite.Invoke(null, [
+                        texture, rect, pivot, pixelsPerUnit, extrude,
+                        meshtype, border, generateFallbackPhysicsShape
+                    ]);
+                }
+                catch (Exception ex)
+                {
+                    Universe.LogWarning(ex);
+                }
             }
-            catch (Exception ex)
+            else
             {
-                Universe.LogWarning(ex);
-            }
-            
-            try
-            {
-                return (Sprite)_spriteCreateSprite.Invoke(null, [
-                    texture, rect, pivot, pixelsPerUnit, extrude,
-                    meshtype, border, generateFallbackPhysicsShape]);
-            }
-            catch (Exception ex)
-            {
-                Universe.LogWarning(ex);
+                d_CreateSprite_Secondary icall_secondary = ICallManager.GetICall<d_CreateSprite_Secondary>("UnityEngine.Sprite::CreateSprite_Injected(System.IntPtr,UnityEngine.Rect&,UnityEngine.Vector2&,System.Single,System.UInt32,System.Int32,UnityEngine.Vector4&,System.Boolean,UnityEngine.SecondarySpriteTexture[])");
+                if (icall_secondary != null)
+                {
+                    IntPtr spritePtr = icall_secondary
+                        .Invoke(texture.GetCachedPtr(), ref rect, ref pivot, pixelsPerUnit, extrude, 1, ref border,
+                        false, null);
+                    
+                    return (Sprite)Type
+                        .GetType("UnityEngine.Bindings.Unmarshal, UnityEngine.CoreModule")
+                        .GetMethod("UnmarshalUnityObject")
+                        .MakeGenericMethod(typeof(Sprite))
+                        .Invoke(null, new object[] { spritePtr });
+                }
+                
+                d_CreateSprite icall = ICallManager.GetICall<d_CreateSprite>("UnityEngine.Sprite::CreateSprite_Injected(System.IntPtr,UnityEngine.Rect&,UnityEngine.Vector2&,System.Single,System.UInt32,System.Int32,UnityEngine.Vector4&,System.Boolean)");
+                if (icall != null)
+                {
+                    IntPtr spritePtr = icall
+                        .Invoke(texture.ToIl2CppPointer(), ref rect, ref pivot, pixelsPerUnit, extrude, 1, ref border,
+                            false);
+                    return spritePtr == IntPtr.Zero ? null : new Sprite(spritePtr);
+                }
             }
 
             return null;

--- a/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
+++ b/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
@@ -126,10 +126,12 @@ namespace UniverseLib.Runtime.Il2Cpp
                 d_CreateSprite_Secondary icall_secondary = ICallManager.GetICall<d_CreateSprite_Secondary>("UnityEngine.Sprite::CreateSprite_Injected(System.IntPtr,UnityEngine.Rect&,UnityEngine.Vector2&,System.Single,System.UInt32,System.Int32,UnityEngine.Vector4&,System.Boolean,UnityEngine.SecondarySpriteTexture[])");
                 if (icall_secondary != null)
                 {
+                    // Unity now calls the ICall with the pointer returned from GetCachedPtr
                     IntPtr spritePtr = icall_secondary
                         .Invoke(texture.GetCachedPtr(), ref rect, ref pivot, pixelsPerUnit, extrude, 1, ref border,
                         false, null);
                     
+                    // Unity now calls Unmarshal.UnmarshalUnityObject with the Sprite pointer returned from the ICall
                     return (Sprite)Type
                         .GetType("UnityEngine.Bindings.Unmarshal, UnityEngine.CoreModule")
                         .GetMethod("UnmarshalUnityObject")

--- a/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
+++ b/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
@@ -79,8 +79,8 @@ namespace UniverseLib.Runtime.Il2Cpp
             typeof(Vector4),
             typeof(bool)
         ];
-        private static MethodInfo _spriteCreate = typeof(Sprite).GetMethod("Create", BindingFlags.Static | BindingFlags.Public, _spriteCreateParams);
-        private static MethodInfo _spriteCreateSprite = typeof(Sprite).GetMethod("CreateSprite", BindingFlags.Static | BindingFlags.Public, _spriteCreateParams);
+        private static MethodInfo _spriteCreate = typeof(Sprite).GetMethod("Create", _spriteCreateParams);
+        private static MethodInfo _spriteCreateSprite = typeof(Sprite).GetMethod("CreateSprite", _spriteCreateParams);
         internal static Sprite CreateSpriteImpl(Texture2D texture, 
             Rect rect, 
             Vector2 pivot, 

--- a/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
+++ b/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
@@ -115,7 +115,6 @@ namespace UniverseLib.Runtime.Il2Cpp
                 Graphics.CopyTexture(
                     src, srcElement, srcMip, srcX, srcY, srcWidth, srcHeight,
                     dst, dstElement, dstMip, dstX, dstY);
-                return dst;
             }
             else
             {

--- a/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
+++ b/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
@@ -84,12 +84,15 @@ namespace UniverseLib.Runtime.Il2Cpp
             try
             {
                 Sprite sprite = Sprite.Create(
-                    texture, rect, pivot, pixelsPerUnit, extrude, 
+                    texture, rect, pivot, pixelsPerUnit, extrude,
                     meshtype, border, generateFallbackPhysicsShape);
                 if (sprite != null)
                     return sprite;
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Universe.LogWarning(ex);
+            }
             
             if (ConfigManager.Bypass_UniverseLib_ICall)
                 return null;

--- a/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
+++ b/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -30,12 +31,12 @@ namespace UniverseLib.Runtime.Il2Cpp
         
         protected internal override Texture2D Internal_NewTexture2D(int width, int height)
         {
-            return new(width, height, TextureFormat.RGBA32, 1, false, IntPtr.Zero);
+            return new(width, height, TextureFormat.RGBA32, false);
         }
 
         protected internal override Texture2D Internal_NewTexture2D(int width, int height, TextureFormat textureFormat, bool mipChain)
         {
-            return new(width, height, textureFormat, mipChain ? -1 : 1, false, IntPtr.Zero);
+            return new(width, height, textureFormat, mipChain);
         }
 
         protected internal override void Internal_Blit(Texture tex, RenderTexture rt)
@@ -70,6 +71,9 @@ namespace UniverseLib.Runtime.Il2Cpp
             return CreateSpriteImpl(texture, rect, pivot, pixelsPerUnit, extrude, SpriteMeshType.Tight, border, false);
         }
 
+        private static MethodInfo _spriteCreateSpriteMethod = typeof(Sprite)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .LastOrDefault(x => x.Name == "CreateSprite");
         internal static Sprite CreateSpriteImpl(Texture2D texture, 
             Rect rect, 
             Vector2 pivot, 
@@ -81,7 +85,8 @@ namespace UniverseLib.Runtime.Il2Cpp
         {
             try
             {
-                Sprite sprite = Sprite.CreateSprite(texture, rect, pivot, pixelsPerUnit, extrude,
+                Sprite sprite = Sprite.Create(
+                    texture, rect, pivot, pixelsPerUnit, extrude, 
                     meshtype, border, generateFallbackPhysicsShape);
                 if (sprite != null)
                     return sprite;
@@ -91,9 +96,7 @@ namespace UniverseLib.Runtime.Il2Cpp
             if (ConfigManager.Bypass_UniverseLib_ICall)
                 return null;
             
-            d_CreateSprite icall = ICallManager.GetICall<d_CreateSprite>("UnityEngine.Sprite::CreateSprite");
-            if (icall == null)
-                icall = ICallManager.GetICall<d_CreateSprite>("UnityEngine.Sprite::CreateSprite_Injected");
+            d_CreateSprite icall = ICallManager.GetICall<d_CreateSprite>("UnityEngine.Sprite::CreateSprite_Injected");
             if (icall == null)
                 return null;
             

--- a/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
+++ b/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
@@ -128,23 +128,21 @@ namespace UniverseLib.Runtime.Il2Cpp
                 {
                     // Unity now calls the ICall with the pointer returned from GetCachedPtr
                     IntPtr spritePtr = icall_secondary
-                        .Invoke(texture.GetCachedPtr(), ref rect, ref pivot, pixelsPerUnit, extrude, 1, ref border,
-                        false, null);
+                        .Invoke(texture.GetCachedPtr(), ref rect, ref pivot, pixelsPerUnit, extrude, (int)meshtype, ref border, generateFallbackPhysicsShape, null);
                     
                     // Unity now calls Unmarshal.UnmarshalUnityObject with the Sprite pointer returned from the ICall
                     return (Sprite)Type
                         .GetType("UnityEngine.Bindings.Unmarshal, UnityEngine.CoreModule")
                         .GetMethod("UnmarshalUnityObject")
                         .MakeGenericMethod(typeof(Sprite))
-                        .Invoke(null, new object[] { spritePtr });
+                        .Invoke(null, [ spritePtr ]);
                 }
                 
                 d_CreateSprite icall = ICallManager.GetICall<d_CreateSprite>("UnityEngine.Sprite::CreateSprite_Injected(System.IntPtr,UnityEngine.Rect&,UnityEngine.Vector2&,System.Single,System.UInt32,System.Int32,UnityEngine.Vector4&,System.Boolean)");
                 if (icall != null)
                 {
                     IntPtr spritePtr = icall
-                        .Invoke(texture.ToIl2CppPointer(), ref rect, ref pivot, pixelsPerUnit, extrude, 1, ref border,
-                            false);
+                        .Invoke(texture.ToIl2CppPointer(), ref rect, ref pivot, pixelsPerUnit, extrude, (int)meshtype, ref border, generateFallbackPhysicsShape);
                     return spritePtr == IntPtr.Zero ? null : new Sprite(spritePtr);
                 }
             }

--- a/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
+++ b/src/Runtime/Il2Cpp/Il2CppTextureHelper.cs
@@ -24,9 +24,6 @@ namespace UniverseLib.Runtime.Il2Cpp
 
         internal delegate void d_Blit2(IntPtr source, IntPtr dest);
 
-        internal delegate IntPtr d_CreateSprite(IntPtr texture, ref Rect rect, ref Vector2 pivot, float pixelsPerUnit,
-            uint extrude, int meshType, ref Vector4 border, bool generateFallbackPhysicsShape);
-
         internal delegate void d_CopyTexture_Region(IntPtr src, int srcElement, int srcMip, int srcX, int srcY,
             int srcWidth, int srcHeight, IntPtr dst, int dstElement, int dstMip, int dstX, int dstY);
         
@@ -72,6 +69,18 @@ namespace UniverseLib.Runtime.Il2Cpp
             return CreateSpriteImpl(texture, rect, pivot, pixelsPerUnit, extrude, SpriteMeshType.Tight, border, false);
         }
 
+        private static Type[] _spriteCreateParams = [ 
+            typeof(Texture2D),
+            typeof(Rect),
+            typeof(Vector2),
+            typeof(float),
+            typeof(uint),
+            typeof(SpriteMeshType),
+            typeof(Vector4),
+            typeof(bool)
+        ];
+        private static MethodInfo _spriteCreate = typeof(Sprite).GetMethod("Create", BindingFlags.Static | BindingFlags.Public, _spriteCreateParams);
+        private static MethodInfo _spriteCreateSprite = typeof(Sprite).GetMethod("CreateSprite", BindingFlags.Static | BindingFlags.Public, _spriteCreateParams);
         internal static Sprite CreateSpriteImpl(Texture2D texture, 
             Rect rect, 
             Vector2 pivot, 
@@ -83,26 +92,27 @@ namespace UniverseLib.Runtime.Il2Cpp
         {
             try
             {
-                Sprite sprite = Sprite.Create(
+                return (Sprite)_spriteCreate.Invoke(null, [
                     texture, rect, pivot, pixelsPerUnit, extrude,
-                    meshtype, border, generateFallbackPhysicsShape);
-                if (sprite != null)
-                    return sprite;
+                    meshtype, border, generateFallbackPhysicsShape]);
             }
             catch (Exception ex)
             {
                 Universe.LogWarning(ex);
             }
             
-            if (ConfigManager.Bypass_UniverseLib_ICall)
-                return null;
-            
-            d_CreateSprite icall = ICallManager.GetICall<d_CreateSprite>("UnityEngine.Sprite::CreateSprite_Injected");
-            if (icall == null)
-                return null;
-            
-            IntPtr spritePtr = icall.Invoke(texture.ToIl2CppPointer(), ref rect, ref pivot, pixelsPerUnit, extrude, 1, ref border, false);
-            return spritePtr == IntPtr.Zero ? null : new Sprite(spritePtr);
+            try
+            {
+                return (Sprite)_spriteCreateSprite.Invoke(null, [
+                    texture, rect, pivot, pixelsPerUnit, extrude,
+                    meshtype, border, generateFallbackPhysicsShape]);
+            }
+            catch (Exception ex)
+            {
+                Universe.LogWarning(ex);
+            }
+
+            return null;
         }
 
         internal override bool Internal_CanForceReadCubemaps => true;

--- a/src/Runtime/Il2Cpp/ManagedSpanWrapper.cs
+++ b/src/Runtime/Il2Cpp/ManagedSpanWrapper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.InteropServices;
 
 namespace UniverseLib
@@ -8,5 +9,25 @@ namespace UniverseLib
     {
         public unsafe void* begin;
         public int length;
+        
+        /// <summary>
+        /// Pins a string and creates a ManagedSpanWrapper using the pinned pointer
+        /// </summary>
+        internal static unsafe void Pin(string str, 
+            Action<ManagedSpanWrapper> act)
+        {
+            fixed (char* charPtr = str) // Pins the string to char*
+            {
+                // Create the new ManagedSpanWrapper
+                var span = new ManagedSpanWrapper
+                {
+                    begin = charPtr,
+                    length = str.Length
+                };
+                
+                // Run Action while string is still pinned
+                act(span);
+            }
+        }
     }
 }

--- a/src/Runtime/Il2Cpp/ManagedSpanWrapper.cs
+++ b/src/Runtime/Il2Cpp/ManagedSpanWrapper.cs
@@ -1,3 +1,4 @@
+#if CPP
 using System;
 using System.Runtime.InteropServices;
 
@@ -13,8 +14,8 @@ namespace UniverseLib
         /// <summary>
         /// Pins a string and creates a ManagedSpanWrapper using the pinned pointer
         /// </summary>
-        internal static unsafe void Pin(string str, 
-            Action<ManagedSpanWrapper> act)
+        internal static unsafe IntPtr Invoke(string str, 
+            Func<ManagedSpanWrapper, IntPtr> act)
         {
             fixed (char* charPtr = str) // Pins the string to char*
             {
@@ -25,9 +26,10 @@ namespace UniverseLib
                     length = str.Length
                 };
                 
-                // Run Action while string is still pinned
-                act(span);
+                // Invoke Func while string is still pinned
+                return act.Invoke(span);
             }
         }
     }
 }
+#endif

--- a/src/Runtime/Il2Cpp/ManagedSpanWrapper.cs
+++ b/src/Runtime/Il2Cpp/ManagedSpanWrapper.cs
@@ -1,0 +1,12 @@
+using System.Runtime.InteropServices;
+
+namespace UniverseLib
+{
+    // New struct needed for Unity 6 function calls.
+    [StructLayout(LayoutKind.Sequential)]
+    public struct ManagedSpanWrapper
+    {
+        public unsafe void* begin;
+        public int length;
+    }
+}

--- a/src/Utility/UnityHelpers.cs
+++ b/src/Utility/UnityHelpers.cs
@@ -10,6 +10,15 @@ using UnityEngine.Events;
 using UnityEngine.UI;
 using Object = UnityEngine.Object;
 
+#if CPP
+#if INTEROP
+using Il2CppInterop.Runtime;
+using Il2CppInterop.Runtime.InteropTypes;
+#else
+using UnhollowerBaseLib;
+#endif
+#endif
+
 namespace UniverseLib.Utility
 {
     public static class UnityHelpers
@@ -133,5 +142,16 @@ namespace UniverseLib.Utility
 
             return onEndEdit.GetValue(_this, null).TryCast<UnityEvent<string>>();
         }
+        
+#if CPP
+        /// <summary>
+        /// Returns the Pointer to any given Il2Cpp Object.
+        /// </summary>
+        internal static IntPtr ToIl2CppPointer<T>(this T obj) 
+            where T : Il2CppObjectBase
+        {
+            return IL2CPP.Il2CppObjectBaseToPtr(obj);
+        }
+#endif
     }
 }

--- a/src/Utility/UnityHelpers.cs
+++ b/src/Utility/UnityHelpers.cs
@@ -150,6 +150,8 @@ namespace UniverseLib.Utility
         internal static IntPtr ToIl2CppPointer<T>(this T obj) 
             where T : Il2CppObjectBase
         {
+            // Get Pointer from Unhollower/Il2CppInterop instead of .Pointer
+            // This ensures greater compatibility with any variation in behavior
             return IL2CPP.Il2CppObjectBaseToPtr(obj);
         }
 #endif


### PR DESCRIPTION
These changes fix the issues that occur from _Injected ICalls being substituted in some Unity versions.
Also adjusts Texture2D and Sprite creation to make the viewer usable again.
Confirmed working on BTD6 and Schedule 1.
<img width="1597" height="925" alt="ue_working_btd6" src="https://github.com/user-attachments/assets/4f88c636-81d5-4759-a471-a79d0e05c8e4" />
<img width="1594" height="922" alt="ue_working_s1" src="https://github.com/user-attachments/assets/5f730577-bea9-41ab-808e-dfbf9c606d8f" />